### PR TITLE
feat: add bank accounts model for automatic debit management

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -110,6 +110,38 @@ DI benefits:
 - Dashboard and CRUD interfaces at root path `/`
 - API endpoints at `/api`
 
+## Git Workflow (MANDATORY)
+
+**ALWAYS follow this workflow when implementing features or fixes:**
+
+1. **Before starting any work:**
+   ```bash
+   git checkout master && git pull origin master
+   git checkout -b feature/<descriptive-name>  # or fix/<descriptive-name>
+   ```
+
+2. **During development:**
+   - Make atomic commits with clear messages
+   - Run tests frequently: `npm test`
+   - Keep changes focused on the feature/fix scope
+
+3. **Before creating PR:**
+   - Run full test suite: `npm test`
+   - Verify no linting errors
+   - Update Swagger docs if API changed
+   - Review all changed files
+
+4. **Creating PR:**
+   - Push branch: `git push -u origin <branch-name>`
+   - Create PR via `gh pr create`
+   - Include summary and test plan in PR description
+
+**Branch naming conventions:**
+- `feature/<name>` - New functionality
+- `fix/<name>` - Bug fixes
+- `refactor/<name>` - Code improvements without behavior change
+- `docs/<name>` - Documentation only
+
 ## Important Notes
 
 - All database operations use the `finanzas` schema

--- a/docs/api/swagger.yaml
+++ b/docs/api/swagger.yaml
@@ -26,6 +26,8 @@ tags:
     description: Operaciones con débitos automáticos (suscripciones, servicios)
   - name: tarjetas
     description: Gestión de tarjetas de débito y crédito del usuario
+  - name: cuentas-bancarias
+    description: Gestión de cuentas bancarias (ahorro/corriente) para débitos automáticos
   - name: tipo-cambio
     description: Sistema multi-moneda - Gestión de tipos de cambio USD/ARS
   - name: proyeccion
@@ -754,6 +756,154 @@ components:
               type: integer
               description: Total de registros que usan esta tarjeta
               example: 7
+
+    CuentaBancaria:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: ID único de la cuenta bancaria
+          example: 1
+        nombre:
+          type: string
+          minLength: 2
+          maxLength: 100
+          description: Nombre descriptivo de la cuenta
+          example: "Cuenta Sueldo Galicia"
+        banco:
+          type: string
+          minLength: 2
+          maxLength: 100
+          description: Nombre del banco
+          example: "Banco Galicia"
+        tipo:
+          type: string
+          enum: [ahorro, corriente]
+          description: Tipo de cuenta
+          example: "ahorro"
+        ultimos_4_digitos:
+          type: string
+          minLength: 4
+          maxLength: 4
+          pattern: '^\d{4}$'
+          nullable: true
+          description: Últimos 4 dígitos del CBU/número de cuenta
+          example: "5678"
+        moneda:
+          type: string
+          enum: [ARS, USD]
+          description: Moneda de la cuenta
+          example: "ARS"
+        activa:
+          type: boolean
+          description: Si la cuenta está activa
+          example: true
+        usuario_id:
+          type: integer
+          description: ID del usuario propietario
+          example: 1
+
+    CuentaBancariaInput:
+      type: object
+      required: [nombre, banco, tipo]
+      properties:
+        nombre:
+          type: string
+          minLength: 2
+          maxLength: 100
+          description: Nombre descriptivo de la cuenta
+          example: "Cuenta Sueldo Galicia"
+        banco:
+          type: string
+          minLength: 2
+          maxLength: 100
+          description: Nombre del banco
+          example: "Banco Galicia"
+        tipo:
+          type: string
+          enum: [ahorro, corriente]
+          description: Tipo de cuenta
+          example: "ahorro"
+        ultimos_4_digitos:
+          type: string
+          minLength: 4
+          maxLength: 4
+          pattern: '^\d{4}$'
+          description: Últimos 4 dígitos del CBU/número de cuenta (opcional)
+          example: "5678"
+        moneda:
+          type: string
+          enum: [ARS, USD]
+          default: ARS
+          description: Moneda de la cuenta
+          example: "ARS"
+        activa:
+          type: boolean
+          default: true
+          description: Si la cuenta está activa
+          example: true
+
+    CuentaBancariaStats:
+      type: object
+      properties:
+        estadisticas:
+          type: object
+          properties:
+            total:
+              type: integer
+              description: Total de cuentas del usuario
+              example: 3
+            ahorro:
+              type: integer
+              description: Cantidad de cuentas de ahorro
+              example: 2
+            corriente:
+              type: integer
+              description: Cantidad de cuentas corrientes
+              example: 1
+            activas:
+              type: integer
+              description: Cantidad de cuentas activas
+              example: 2
+            inactivas:
+              type: integer
+              description: Cantidad de cuentas inactivas
+              example: 1
+        usuario_id:
+          type: integer
+          description: ID del usuario
+          example: 1
+
+    CuentaBancariaUsage:
+      type: object
+      properties:
+        cuenta:
+          type: object
+          properties:
+            id:
+              type: integer
+              example: 1
+            nombre:
+              type: string
+              example: "Cuenta Sueldo Galicia"
+            tipo:
+              type: string
+              example: "ahorro"
+        inUse:
+          type: boolean
+          description: Indica si la cuenta está siendo utilizada
+          example: false
+        usage:
+          type: object
+          properties:
+            debitosAutomaticos:
+              type: integer
+              description: Cantidad de débitos automáticos que usan esta cuenta
+              example: 3
+            total:
+              type: integer
+              description: Total de registros que usan esta cuenta
+              example: 3
 
     Frecuencia:
       type: object
@@ -3492,6 +3642,279 @@ paths:
                     total: 7
         '404':
           description: Tarjeta no encontrada
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  # =============================================================================
+  # CUENTAS BANCARIAS ENDPOINTS
+  # =============================================================================
+  /cuentas-bancarias:
+    get:
+      tags:
+        - cuentas-bancarias
+      summary: Listar cuentas bancarias del usuario
+      description: |
+        Obtiene todas las cuentas bancarias del usuario autenticado con filtros opcionales.
+
+        **Filtros disponibles:**
+        - `tipo`: Filtrar por tipo de cuenta (ahorro, corriente)
+        - `banco`: Búsqueda parcial por nombre del banco
+        - `moneda`: Filtrar por moneda (ARS, USD)
+        - `activa`: Filtrar por estado activo (true/false)
+        - `limit`: Límite de resultados (1-100)
+        - `offset`: Offset para paginación
+        - `orderBy`: Campo de ordenamiento (nombre, tipo, banco, id)
+        - `orderDirection`: Dirección del ordenamiento (ASC, DESC)
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: tipo
+          in: query
+          schema:
+            type: string
+            enum: [ahorro, corriente]
+          description: Filtrar por tipo de cuenta
+        - name: banco
+          in: query
+          schema:
+            type: string
+          description: Búsqueda parcial por nombre del banco
+        - name: moneda
+          in: query
+          schema:
+            type: string
+            enum: [ARS, USD]
+          description: Filtrar por moneda
+        - name: activa
+          in: query
+          schema:
+            type: string
+            enum: ["true", "false"]
+          description: Filtrar por estado activo
+        - name: limit
+          in: query
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 100
+        - name: offset
+          in: query
+          schema:
+            type: integer
+            minimum: 0
+        - name: orderBy
+          in: query
+          schema:
+            type: string
+            enum: [nombre, tipo, banco, id]
+        - name: orderDirection
+          in: query
+          schema:
+            type: string
+            enum: [ASC, DESC]
+      responses:
+        '200':
+          description: Lista de cuentas bancarias obtenida exitosamente
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/StandardResponse'
+                  - type: object
+                    properties:
+                      data:
+                        type: array
+                        items:
+                          $ref: '#/components/schemas/CuentaBancaria'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+    post:
+      tags:
+        - cuentas-bancarias
+      summary: Crear nueva cuenta bancaria
+      description: Crea una nueva cuenta bancaria para el usuario autenticado.
+      security:
+        - BearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CuentaBancariaInput'
+            examples:
+              ahorro:
+                summary: Cuenta de ahorro
+                value:
+                  nombre: "Cuenta Sueldo Galicia"
+                  banco: "Banco Galicia"
+                  tipo: "ahorro"
+                  moneda: "ARS"
+              corriente:
+                summary: Cuenta corriente
+                value:
+                  nombre: "Cuenta Corriente BBVA"
+                  banco: "BBVA"
+                  tipo: "corriente"
+                  ultimos_4_digitos: "5678"
+      responses:
+        '201':
+          description: Cuenta bancaria creada exitosamente
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/StandardResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/CuentaBancaria'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /cuentas-bancarias/stats:
+    get:
+      tags:
+        - cuentas-bancarias
+      summary: Obtener estadísticas de cuentas bancarias
+      description: Obtiene estadísticas resumidas de las cuentas bancarias del usuario.
+      security:
+        - BearerAuth: []
+      responses:
+        '200':
+          description: Estadísticas obtenidas exitosamente
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/StandardResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/CuentaBancariaStats'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /cuentas-bancarias/{id}:
+    get:
+      tags:
+        - cuentas-bancarias
+      summary: Obtener cuenta bancaria por ID
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Cuenta bancaria obtenida exitosamente
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/StandardResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/CuentaBancaria'
+        '404':
+          description: Cuenta bancaria no encontrada
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+    put:
+      tags:
+        - cuentas-bancarias
+      summary: Actualizar cuenta bancaria
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CuentaBancariaInput'
+      responses:
+        '200':
+          description: Cuenta bancaria actualizada exitosamente
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/StandardResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/CuentaBancaria'
+        '400':
+          $ref: '#/components/responses/ValidationError'
+        '404':
+          description: Cuenta bancaria no encontrada
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+    delete:
+      tags:
+        - cuentas-bancarias
+      summary: Eliminar cuenta bancaria
+      description: Elimina una cuenta bancaria. Falla si está en uso por débitos automáticos.
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Cuenta bancaria eliminada exitosamente
+        '400':
+          description: La cuenta está en uso y no puede eliminarse
+        '404':
+          description: Cuenta bancaria no encontrada
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+
+  /cuentas-bancarias/{id}/usage:
+    get:
+      tags:
+        - cuentas-bancarias
+      summary: Validar uso de cuenta bancaria
+      description: Verifica si la cuenta bancaria está siendo utilizada por débitos automáticos.
+      security:
+        - BearerAuth: []
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Estado de uso obtenido exitosamente
+          content:
+            application/json:
+              schema:
+                allOf:
+                  - $ref: '#/components/schemas/StandardResponse'
+                  - type: object
+                    properties:
+                      data:
+                        $ref: '#/components/schemas/CuentaBancariaUsage'
+        '404':
+          description: Cuenta bancaria no encontrada
         '401':
           $ref: '#/components/responses/Unauthorized'
 

--- a/src/controllers/api/cuentaBancaria.controller.js
+++ b/src/controllers/api/cuentaBancaria.controller.js
@@ -1,0 +1,212 @@
+import { BaseController } from './base.controller.js';
+import { CuentaBancaria } from '../../models/index.js';
+import { CuentaBancariaService } from '../../services/cuentaBancaria.service.js';
+import { sendError, sendSuccess, sendPaginatedSuccess } from '../../utils/responseHelper.js';
+import logger from '../../utils/logger.js';
+
+export class CuentaBancariaController extends BaseController {
+  constructor() {
+    super(CuentaBancaria, 'CuentaBancaria');
+    this.cuentaBancariaService = new CuentaBancariaService();
+  }
+
+  getIncludes() {
+    return [];
+  }
+
+  getRelationships() {
+    return {};
+  }
+
+  /**
+   * Obtiene todas las cuentas bancarias del usuario con filtros opcionales
+   */
+  async getWithFilters(req, res) {
+    try {
+      const result = await this.cuentaBancariaService.getWithFilters(req.query, req.user.id);
+
+      if (result.meta.limit && result.meta.limit < result.meta.total) {
+        return sendPaginatedSuccess(res, result.data, result.meta);
+      }
+
+      return sendSuccess(res, result.data);
+    } catch (error) {
+      logger.error('Error al obtener cuentas bancarias con filtros:', { error, userId: req.user.id });
+      return sendError(res, 500, 'Error al obtener cuentas bancarias', error.message);
+    }
+  }
+
+  /**
+   * Obtiene una cuenta bancaria por ID (solo si pertenece al usuario)
+   */
+  async getById(req, res) {
+    try {
+      const cuenta = await this.cuentaBancariaService.findByIdAndUser(req.params.id, req.user.id);
+
+      if (!cuenta) {
+        return sendError(res, 404, 'Cuenta bancaria no encontrada');
+      }
+
+      return sendSuccess(res, cuenta);
+    } catch (error) {
+      logger.error('Error al obtener cuenta bancaria por ID:', { error, cuentaId: req.params.id, userId: req.user.id });
+      return sendError(res, 500, 'Error al obtener cuenta bancaria', error.message);
+    }
+  }
+
+  /**
+   * Crea una nueva cuenta bancaria para el usuario autenticado
+   */
+  async create(req, res) {
+    try {
+      // Normalizar datos
+      const normalizedData = this.cuentaBancariaService.normalizeCuentaData(req.body);
+
+      // Asignar usuario autenticado
+      normalizedData.usuario_id = req.user.id;
+
+      const cuenta = await this.model.create(normalizedData);
+
+      logger.info('Cuenta bancaria creada exitosamente:', {
+        cuentaId: cuenta.id,
+        userId: req.user.id,
+        tipo: cuenta.tipo,
+        nombre: cuenta.nombre
+      });
+
+      return sendSuccess(res, cuenta, 201);
+    } catch (error) {
+      logger.error('Error al crear cuenta bancaria:', { error, userId: req.user.id, data: req.body });
+      return sendError(res, 500, 'Error al crear cuenta bancaria', error.message);
+    }
+  }
+
+  /**
+   * Actualiza una cuenta bancaria (solo si pertenece al usuario)
+   */
+  async update(req, res) {
+    try {
+      // Verificar que la cuenta pertenece al usuario
+      const cuenta = await this.cuentaBancariaService.findByIdAndUser(req.params.id, req.user.id);
+      if (!cuenta) {
+        return sendError(res, 404, 'Cuenta bancaria no encontrada');
+      }
+
+      // Normalizar datos
+      const normalizedData = this.cuentaBancariaService.normalizeCuentaData(req.body);
+
+      // No permitir cambiar el usuario_id
+      delete normalizedData.usuario_id;
+
+      await cuenta.update(normalizedData);
+
+      logger.info('Cuenta bancaria actualizada exitosamente:', {
+        cuentaId: cuenta.id,
+        userId: req.user.id,
+        tipo: cuenta.tipo
+      });
+
+      return sendSuccess(res, cuenta);
+    } catch (error) {
+      logger.error('Error al actualizar cuenta bancaria:', { error, cuentaId: req.params.id, userId: req.user.id });
+      return sendError(res, 500, 'Error al actualizar cuenta bancaria', error.message);
+    }
+  }
+
+  /**
+   * Elimina una cuenta bancaria (solo si pertenece al usuario y no está en uso)
+   */
+  async delete(req, res) {
+    try {
+      // Verificar que la cuenta pertenece al usuario
+      const cuenta = await this.cuentaBancariaService.findByIdAndUser(req.params.id, req.user.id);
+      if (!cuenta) {
+        return sendError(res, 404, 'Cuenta bancaria no encontrada');
+      }
+
+      // Verificar si la cuenta está en uso
+      const usageValidation = await this.cuentaBancariaService.validateCuentaUsage(cuenta.id);
+      if (usageValidation.inUse) {
+        return sendError(res, 400, 'No se puede eliminar la cuenta bancaria',
+          `La cuenta está siendo utilizada en ${usageValidation.usage.total} débito(s) automático(s)`
+        );
+      }
+
+      await cuenta.destroy();
+
+      logger.info('Cuenta bancaria eliminada exitosamente:', {
+        cuentaId: cuenta.id,
+        userId: req.user.id,
+        nombre: cuenta.nombre
+      });
+
+      return sendSuccess(res, {
+        message: 'Cuenta bancaria eliminada exitosamente',
+        cuenta: {
+          id: cuenta.id,
+          nombre: cuenta.nombre,
+          tipo: cuenta.tipo
+        }
+      });
+    } catch (error) {
+      logger.error('Error al eliminar cuenta bancaria:', { error, cuentaId: req.params.id, userId: req.user.id });
+      return sendError(res, 500, 'Error al eliminar cuenta bancaria', error.message);
+    }
+  }
+
+  /**
+   * Obtiene estadísticas de cuentas bancarias del usuario
+   */
+  async getStats(req, res) {
+    try {
+      const stats = await this.cuentaBancariaService.getUserAccountStats(req.user.id);
+
+      return sendSuccess(res, {
+        estadisticas: stats,
+        usuario_id: req.user.id
+      });
+    } catch (error) {
+      logger.error('Error al obtener estadísticas de cuentas bancarias:', { error, userId: req.user.id });
+      return sendError(res, 500, 'Error al obtener estadísticas', error.message);
+    }
+  }
+
+  /**
+   * Valida el uso de una cuenta bancaria específica
+   */
+  async validateUsage(req, res) {
+    try {
+      // Verificar que la cuenta pertenece al usuario
+      const cuenta = await this.cuentaBancariaService.findByIdAndUser(req.params.id, req.user.id);
+      if (!cuenta) {
+        return sendError(res, 404, 'Cuenta bancaria no encontrada');
+      }
+
+      const usageValidation = await this.cuentaBancariaService.validateCuentaUsage(cuenta.id);
+
+      return sendSuccess(res, {
+        cuenta: {
+          id: cuenta.id,
+          nombre: cuenta.nombre,
+          tipo: cuenta.tipo
+        },
+        ...usageValidation
+      });
+    } catch (error) {
+      logger.error('Error al validar uso de cuenta bancaria:', { error, cuentaId: req.params.id, userId: req.user.id });
+      return sendError(res, 500, 'Error al validar uso de cuenta bancaria', error.message);
+    }
+  }
+}
+
+// Crear instancia del controlador
+const cuentaBancariaController = new CuentaBancariaController();
+
+// Exportar métodos
+export const obtenerCuentasBancarias = cuentaBancariaController.getWithFilters.bind(cuentaBancariaController);
+export const obtenerCuentaBancariaPorId = cuentaBancariaController.getById.bind(cuentaBancariaController);
+export const crearCuentaBancaria = cuentaBancariaController.create.bind(cuentaBancariaController);
+export const actualizarCuentaBancaria = cuentaBancariaController.update.bind(cuentaBancariaController);
+export const eliminarCuentaBancaria = cuentaBancariaController.delete.bind(cuentaBancariaController);
+export const obtenerEstadisticasCuentasBancarias = cuentaBancariaController.getStats.bind(cuentaBancariaController);
+export const validarUsoCuentaBancaria = cuentaBancariaController.validateUsage.bind(cuentaBancariaController);

--- a/src/middlewares/validation.middleware.js
+++ b/src/middlewares/validation.middleware.js
@@ -133,6 +133,12 @@ const debitoAutomaticoSchema = Joi.object({
   importancia_gasto_id: baseGastoSchema.importancia_gasto_id,
   tipo_pago_id: baseGastoSchema.tipo_pago_id,
   tarjeta_id: baseGastoSchema.tarjeta_id,
+  cuenta_bancaria_id: Joi.number().integer().positive().allow(null).optional()
+    .messages({
+      'number.base': 'La cuenta bancaria debe ser un número',
+      'number.integer': 'La cuenta bancaria debe ser un número entero',
+      'number.positive': 'La cuenta bancaria debe ser un ID válido'
+    }),
   // dia_de_pago is optional when using credit card (uses card's due date)
   dia_de_pago: Joi.number().integer().min(1).max(31).allow(null)
     .messages({
@@ -235,6 +241,7 @@ const debitoAutomaticoFiltersSchema = Joi.object({
   importancia_gasto_id: Joi.number().integer().positive().optional(),
   tipo_pago_id: Joi.number().integer().positive().optional(),
   tarjeta_id: Joi.number().integer().positive().optional(),
+  cuenta_bancaria_id: Joi.number().integer().positive().optional(),
   frecuencia_gasto_id: Joi.number().integer().positive().optional(),
   monto_min: Joi.number().positive().optional(),
   monto_max: Joi.number().positive().min(Joi.ref('monto_min')).optional(),
@@ -688,3 +695,98 @@ export const validateIngresoUnicoFilters = createValidationMiddleware(ingresoUni
 export const validateCreateIngresoRecurrente = createValidationMiddleware(ingresoRecurrenteSchema, 'body');
 export const validateUpdateIngresoRecurrente = createValidationMiddleware(ingresoRecurrenteSchema, 'body');
 export const validateIngresoRecurrenteFilters = createValidationMiddleware(ingresoRecurrenteFiltersSchema, 'query');
+
+// =============================================================================
+// CUENTAS BANCARIAS VALIDATIONS
+// =============================================================================
+
+const cuentaBancariaSchema = Joi.object({
+  nombre: Joi.string().trim().min(2).max(100).required()
+    .messages({
+      'string.min': 'El nombre debe tener al menos 2 caracteres',
+      'string.max': 'El nombre no puede exceder 100 caracteres',
+      'any.required': 'El nombre de la cuenta es requerido'
+    }),
+
+  banco: Joi.string().trim().min(2).max(100).required()
+    .messages({
+      'string.min': 'El banco debe tener al menos 2 caracteres',
+      'string.max': 'El banco no puede exceder 100 caracteres',
+      'any.required': 'El banco es requerido'
+    }),
+
+  tipo: Joi.string().valid('ahorro', 'corriente').required()
+    .messages({
+      'any.only': 'El tipo debe ser: ahorro o corriente',
+      'any.required': 'El tipo de cuenta es requerido'
+    }),
+
+  ultimos_4_digitos: Joi.string().length(4).pattern(/^\d{4}$/).optional().allow(null, '')
+    .messages({
+      'string.length': 'Debe ingresar exactamente 4 dígitos',
+      'string.pattern.base': 'Solo se permiten números'
+    }),
+
+  moneda: Joi.string().valid('ARS', 'USD').default('ARS')
+    .messages({
+      'any.only': 'La moneda debe ser: ARS o USD'
+    }),
+
+  activa: Joi.boolean().default(true)
+    .messages({
+      'boolean.base': 'El campo activa debe ser verdadero o falso'
+    })
+});
+
+const cuentaBancariaFiltersSchema = Joi.object({
+  tipo: Joi.string().valid('ahorro', 'corriente').optional()
+    .messages({
+      'any.only': 'El tipo debe ser: ahorro o corriente'
+    }),
+
+  banco: Joi.string().trim().min(1).max(100).optional()
+    .messages({
+      'string.min': 'El banco debe tener al menos 1 caracter para la búsqueda',
+      'string.max': 'El banco no puede exceder 100 caracteres'
+    }),
+
+  moneda: Joi.string().valid('ARS', 'USD').optional()
+    .messages({
+      'any.only': 'La moneda debe ser: ARS o USD'
+    }),
+
+  activa: Joi.string().valid('true', 'false').optional()
+    .messages({
+      'any.only': 'El campo activa debe ser "true" o "false"'
+    }),
+
+  limit: Joi.number().integer().min(1).max(100).optional()
+    .messages({
+      'number.base': 'El límite debe ser un número',
+      'number.integer': 'El límite debe ser un número entero',
+      'number.min': 'El límite debe ser al menos 1',
+      'number.max': 'El límite no puede ser mayor a 100'
+    }),
+
+  offset: Joi.number().integer().min(0).optional()
+    .messages({
+      'number.base': 'El offset debe ser un número',
+      'number.integer': 'El offset debe ser un número entero',
+      'number.min': 'El offset debe ser 0 o mayor'
+    }),
+
+  orderBy: Joi.string().valid('nombre', 'tipo', 'banco', 'id').optional()
+    .messages({
+      'any.only': 'El ordenamiento debe ser por: nombre, tipo, banco o id'
+    }),
+
+  orderDirection: Joi.string().valid('ASC', 'DESC').optional()
+    .messages({
+      'any.only': 'La dirección debe ser ASC o DESC'
+    })
+});
+
+// Exportar validaciones de cuentas bancarias
+export const validateCreateCuentaBancaria = createValidationMiddleware(cuentaBancariaSchema, 'body');
+export const validateUpdateCuentaBancaria = createValidationMiddleware(cuentaBancariaSchema, 'body');
+export const validateCuentaBancariaFilters = createValidationMiddleware(cuentaBancariaFiltersSchema, 'query');

--- a/src/models/CuentaBancaria.model.js
+++ b/src/models/CuentaBancaria.model.js
@@ -1,0 +1,64 @@
+import { DataTypes } from 'sequelize';
+
+export function defineCuentaBancaria(sequelize) {
+  return sequelize.define('CuentaBancaria', {
+    id: {
+      type: DataTypes.INTEGER,
+      primaryKey: true,
+      autoIncrement: true
+    },
+    nombre: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      comment: 'Nombre descriptivo de la cuenta (ej: "Cuenta Sueldo Galicia")'
+    },
+    banco: {
+      type: DataTypes.STRING,
+      allowNull: false,
+      comment: 'Nombre del banco'
+    },
+    tipo: {
+      type: DataTypes.ENUM('ahorro', 'corriente'),
+      allowNull: false,
+      comment: 'Tipo de cuenta: ahorro o corriente'
+    },
+    ultimos_4_digitos: {
+      type: DataTypes.STRING(4),
+      allowNull: true,
+      validate: {
+        validFormat(value) {
+          if (value !== null && value !== '') {
+            if (value.length !== 4 || !/^\d{4}$/.test(value)) {
+              throw new Error('Debe ingresar exactamente 4 dígitos numéricos');
+            }
+          }
+        }
+      },
+      comment: 'Últimos 4 dígitos del CBU/número de cuenta para identificación'
+    },
+    moneda: {
+      type: DataTypes.ENUM('ARS', 'USD'),
+      allowNull: false,
+      defaultValue: 'ARS',
+      comment: 'Moneda de la cuenta'
+    },
+    activa: {
+      type: DataTypes.BOOLEAN,
+      allowNull: false,
+      defaultValue: true,
+      comment: 'Si la cuenta está activa'
+    },
+    usuario_id: {
+      type: DataTypes.INTEGER,
+      allowNull: false,
+      references: {
+        model: 'usuarios',
+        key: 'id'
+      },
+      comment: 'Usuario propietario de la cuenta'
+    }
+  }, {
+    tableName: 'cuentas_bancarias',
+    timestamps: true
+  });
+}

--- a/src/models/DebitoAutomatico.model.js
+++ b/src/models/DebitoAutomatico.model.js
@@ -77,6 +77,15 @@ export function defineDebitoAutomatico(sequelize) {
         key: 'id'
       }
     },
+    cuenta_bancaria_id: {
+      type: DataTypes.INTEGER,
+      allowNull: true,
+      references: {
+        model: 'cuentas_bancarias',
+        key: 'id'
+      },
+      comment: 'Cuenta bancaria de la cual se debita (alternativa a tarjeta)'
+    },
     usuario_id: {
       type: DataTypes.INTEGER,
       allowNull: false,

--- a/src/models/associations.js
+++ b/src/models/associations.js
@@ -13,7 +13,8 @@ export function setupAssociations(models) {
     Usuario,
     FuenteIngreso,
     IngresoUnico,
-    IngresoRecurrente
+    IngresoRecurrente,
+    CuentaBancaria
   } = models;
 
   // Gasto
@@ -66,6 +67,9 @@ export function setupAssociations(models) {
 
   DebitoAutomatico.belongsTo(Tarjeta, { foreignKey: 'tarjeta_id', as: 'tarjeta' });
   Tarjeta.hasMany(DebitoAutomatico, { foreignKey: 'tarjeta_id', as: 'debitos' });
+
+  DebitoAutomatico.belongsTo(CuentaBancaria, { foreignKey: 'cuenta_bancaria_id', as: 'cuentaBancaria' });
+  CuentaBancaria.hasMany(DebitoAutomatico, { foreignKey: 'cuenta_bancaria_id', as: 'debitosAutomaticos' });
 
   DebitoAutomatico.belongsTo(Usuario, { foreignKey: 'usuario_id', as: 'usuario' });
   Usuario.hasMany(DebitoAutomatico, { foreignKey: 'usuario_id', as: 'debitosAutomaticos' });
@@ -125,5 +129,9 @@ export function setupAssociations(models) {
 
   IngresoRecurrente.belongsTo(Usuario, { foreignKey: 'usuario_id', as: 'usuario' });
   Usuario.hasMany(IngresoRecurrente, { foreignKey: 'usuario_id', as: 'ingresosRecurrentes' });
+
+  // Cuenta Bancaria
+  CuentaBancaria.belongsTo(Usuario, { foreignKey: 'usuario_id', as: 'usuario' });
+  Usuario.hasMany(CuentaBancaria, { foreignKey: 'usuario_id', as: 'cuentasBancarias' });
 
 }

--- a/src/models/index.js
+++ b/src/models/index.js
@@ -15,6 +15,7 @@ import { defineTipoCambio } from './TipoCambio.model.js';
 import { defineFuenteIngreso } from './fuenteIngreso.model.js';
 import { defineIngresoUnico } from './ingresoUnico.model.js';
 import { defineIngresoRecurrente } from './ingresoRecurrente.model.js';
+import { defineCuentaBancaria } from './CuentaBancaria.model.js';
 
 // Configuración para PostgreSQL
 const isProduction = process.env.NODE_ENV === 'production';
@@ -60,7 +61,8 @@ const models = {
   TipoCambio: defineTipoCambio(sequelize),
   FuenteIngreso: defineFuenteIngreso(sequelize),
   IngresoUnico: defineIngresoUnico(sequelize),
-  IngresoRecurrente: defineIngresoRecurrente(sequelize)
+  IngresoRecurrente: defineIngresoRecurrente(sequelize),
+  CuentaBancaria: defineCuentaBancaria(sequelize)
 };
 
 // Relacionamos los modelos
@@ -82,5 +84,6 @@ export const {
   TipoCambio,
   FuenteIngreso,
   IngresoUnico,
-  IngresoRecurrente
+  IngresoRecurrente,
+  CuentaBancaria
 } = models;

--- a/src/routes/api/index.routes.js
+++ b/src/routes/api/index.routes.js
@@ -73,6 +73,16 @@ import {
 } from '../../controllers/api/tarjeta.controller.js';
 
 import {
+  obtenerCuentasBancarias,
+  obtenerCuentaBancariaPorId,
+  crearCuentaBancaria,
+  actualizarCuentaBancaria,
+  eliminarCuentaBancaria,
+  obtenerEstadisticasCuentasBancarias,
+  validarUsoCuentaBancaria
+} from '../../controllers/api/cuentaBancaria.controller.js';
+
+import {
   obtenerTipoCambioActual,
   obtenerHistoricoTipoCambio,
   configurarTipoCambioManual,
@@ -116,7 +126,10 @@ import {
   validateIngresoUnicoFilters,
   validateCreateIngresoRecurrente,
   validateUpdateIngresoRecurrente,
-  validateIngresoRecurrenteFilters
+  validateIngresoRecurrenteFilters,
+  validateCreateCuentaBancaria,
+  validateUpdateCuentaBancaria,
+  validateCuentaBancariaFilters
 } from '../../middlewares/validation.middleware.js';
 
 import { obtenerProyeccion } from '../../controllers/api/proyeccion.controller.js';
@@ -192,6 +205,15 @@ router.get('/tarjetas/:id/usage', authenticateToken, validateIdParam, validarUso
 router.post('/tarjetas', authenticateToken, validateCreateTarjeta, crearTarjeta);
 router.put('/tarjetas/:id', authenticateToken, validateIdParam, validateUpdateTarjeta, actualizarTarjeta);
 router.delete('/tarjetas/:id', authenticateToken, validateIdParam, eliminarTarjeta);
+
+// 🏦 Rutas para Cuentas Bancarias - Requieren autenticación
+router.get('/cuentas-bancarias', authenticateToken, validateCuentaBancariaFilters, obtenerCuentasBancarias);
+router.get('/cuentas-bancarias/stats', authenticateToken, obtenerEstadisticasCuentasBancarias);
+router.get('/cuentas-bancarias/:id', authenticateToken, validateIdParam, obtenerCuentaBancariaPorId);
+router.get('/cuentas-bancarias/:id/usage', authenticateToken, validateIdParam, validarUsoCuentaBancaria);
+router.post('/cuentas-bancarias', authenticateToken, validateCreateCuentaBancaria, crearCuentaBancaria);
+router.put('/cuentas-bancarias/:id', authenticateToken, validateIdParam, validateUpdateCuentaBancaria, actualizarCuentaBancaria);
+router.delete('/cuentas-bancarias/:id', authenticateToken, validateIdParam, eliminarCuentaBancaria);
 
 // 💱 Rutas para Tipo de Cambio - Requieren autenticación
 router.get('/tipo-cambio/actual', authenticateToken, obtenerTipoCambioActual); // Obtener TC actual

--- a/src/services/cuentaBancaria.service.js
+++ b/src/services/cuentaBancaria.service.js
@@ -1,0 +1,192 @@
+import { BaseService } from './base.service.js';
+import { CuentaBancaria, DebitoAutomatico } from '../models/index.js';
+import logger from '../utils/logger.js';
+import { Op } from 'sequelize';
+
+export class CuentaBancariaService extends BaseService {
+  constructor() {
+    super(CuentaBancaria);
+  }
+
+  /**
+   * Busca una cuenta bancaria por ID que pertenezca al usuario
+   * @param {number} id - ID de la cuenta
+   * @param {number} userId - ID del usuario
+   * @returns {Promise<Object|null>} - Cuenta encontrada o null
+   */
+  async findByIdAndUser(id, userId) {
+    try {
+      return await this.model.findOne({
+        where: {
+          id,
+          usuario_id: userId
+        }
+      });
+    } catch (error) {
+      logger.error('Error al buscar cuenta bancaria por ID y usuario:', { error, id, userId });
+      throw error;
+    }
+  }
+
+  /**
+   * Valida si una cuenta bancaria está en uso por débitos automáticos
+   * @param {number} cuentaId - ID de la cuenta
+   * @returns {Promise<{inUse: boolean, usage: Object}>} - Estado de uso
+   */
+  async validateCuentaUsage(cuentaId) {
+    try {
+      const debitosCount = await DebitoAutomatico.count({
+        where: { cuenta_bancaria_id: cuentaId }
+      });
+
+      return {
+        inUse: debitosCount > 0,
+        usage: {
+          debitosAutomaticos: debitosCount,
+          total: debitosCount
+        }
+      };
+    } catch (error) {
+      logger.error('Error al validar uso de cuenta bancaria:', { error, cuentaId });
+      throw error;
+    }
+  }
+
+  /**
+   * Normaliza los datos de la cuenta bancaria
+   * @param {Object} cuentaData - Datos de la cuenta
+   * @returns {Object} - Datos normalizados
+   */
+  normalizeCuentaData(cuentaData) {
+    const normalized = { ...cuentaData };
+
+    // Limpiar strings
+    if (normalized.nombre) {
+      normalized.nombre = normalized.nombre.trim();
+    }
+    if (normalized.banco) {
+      normalized.banco = normalized.banco.trim();
+    }
+
+    // Normalizar ultimos_4_digitos: empty string -> null
+    if (!normalized.ultimos_4_digitos) {
+      normalized.ultimos_4_digitos = null;
+    }
+
+    return normalized;
+  }
+
+  /**
+   * Obtiene cuentas bancarias con filtros para un usuario específico
+   * @param {Object} filters - Filtros a aplicar
+   * @param {number} userId - ID del usuario
+   * @returns {Promise<Object>} - Resultado paginado
+   */
+  async getWithFilters(filters, userId) {
+    try {
+      const {
+        tipo,
+        banco,
+        moneda,
+        activa,
+        limit,
+        offset = 0,
+        orderBy = 'nombre',
+        orderDirection = 'ASC'
+      } = filters;
+
+      // Siempre filtrar por usuario
+      const where = {
+        usuario_id: userId
+      };
+
+      // Aplicar filtros opcionales
+      if (tipo) {
+        where.tipo = tipo;
+      }
+
+      if (banco) {
+        where.banco = {
+          [Op.iLike]: `%${banco}%`
+        };
+      }
+
+      if (moneda) {
+        where.moneda = moneda;
+      }
+
+      if (activa !== undefined) {
+        where.activa = activa === 'true' || activa === true;
+      }
+
+      const queryOptions = {
+        where,
+        order: [[orderBy, orderDirection]]
+      };
+
+      // Aplicar paginación si se especifica
+      if (limit) {
+        queryOptions.limit = parseInt(limit);
+        queryOptions.offset = parseInt(offset);
+      }
+
+      const result = await this.model.findAndCountAll(queryOptions);
+
+      return {
+        data: result.rows,
+        meta: {
+          total: result.count,
+          count: result.rows.length,
+          offset: parseInt(offset),
+          limit: limit ? parseInt(limit) : result.count
+        }
+      };
+    } catch (error) {
+      logger.error('Error al obtener cuentas bancarias con filtros:', { error, filters, userId });
+      throw error;
+    }
+  }
+
+  /**
+   * Verifica si el usuario es dueño de la cuenta
+   * @param {number} cuentaId - ID de la cuenta
+   * @param {number} userId - ID del usuario
+   * @returns {Promise<boolean>} - true si es dueño
+   */
+  async isOwner(cuentaId, userId) {
+    try {
+      const cuenta = await this.findByIdAndUser(cuentaId, userId);
+      return cuenta !== null;
+    } catch (error) {
+      logger.error('Error al verificar ownership de cuenta bancaria:', { error, cuentaId, userId });
+      return false;
+    }
+  }
+
+  /**
+   * Obtiene estadísticas de uso de cuentas bancarias para un usuario
+   * @param {number} userId - ID del usuario
+   * @returns {Promise<Object>} - Estadísticas
+   */
+  async getUserAccountStats(userId) {
+    try {
+      const [totalCuentas, cuentasAhorro, cuentasCorriente, cuentasActivas] = await Promise.all([
+        this.model.count({ where: { usuario_id: userId } }),
+        this.model.count({ where: { usuario_id: userId, tipo: 'ahorro' } }),
+        this.model.count({ where: { usuario_id: userId, tipo: 'corriente' } }),
+        this.model.count({ where: { usuario_id: userId, activa: true } })
+      ]);
+
+      return {
+        total: totalCuentas,
+        ahorro: cuentasAhorro,
+        corriente: cuentasCorriente,
+        activas: cuentasActivas,
+        inactivas: totalCuentas - cuentasActivas
+      };
+    } catch (error) {
+      logger.error('Error al obtener estadísticas de cuentas bancarias:', { error, userId });
+      throw error;
+    }
+  }
+}

--- a/tests/integration/auth.integration.test.js
+++ b/tests/integration/auth.integration.test.js
@@ -37,6 +37,7 @@ jest.unstable_mockModule('../../src/models/index.js', () => ({
   FuenteIngreso: {},
   IngresoUnico: {},
   IngresoRecurrente: {},
+  CuentaBancaria: {},
   TipoCambio: { findOne: jest.fn(), findAll: jest.fn(), create: jest.fn() },
   UserCategoriaPreference: {},
   UserFuenteIngresoPreference: {},


### PR DESCRIPTION
## Summary
- Add `CuentaBancaria` model with fields: nombre, banco, tipo (ahorro/corriente), moneda (ARS/USD), ultimos_4_digitos
- Add `cuenta_bancaria_id` FK to `DebitoAutomatico` model to track which bank account debits are charged from
- Create full CRUD API endpoints for bank accounts (`/api/cuentas-bancarias`)
- Add validation middleware and Swagger documentation
- Update CLAUDE.md with mandatory git workflow instructions

## Why
This enables users to:
1. Track which bank account their automatic debits are charged from
2. Have visibility over debit sources per account
3. Support the UX improvement where `dia_de_pago` is hidden when using credit card (already supported in backend)

## Test plan
- [ ] Run `npm test` - all 357 tests pass
- [ ] Test CRUD operations for bank accounts via Swagger
- [ ] Test creating automatic debit with `cuenta_bancaria_id`
- [ ] Verify bank account deletion is blocked if in use

🤖 Generated with [Claude Code](https://claude.com/claude-code)