### PR TITLE
feat: allow users to hide system categories and income sources

### DIFF
--- a/migrations/021_add_categorias_fuentes_ocultas.sql
+++ b/migrations/021_add_categorias_fuentes_ocultas.sql
@@ -1,0 +1,15 @@
+-- Migration: Add categorias_ocultas and fuentes_ocultas to preferencias_usuario
+-- Date: 2026-03-09
+-- Description: Allows users to hide system categories and income sources
+
+-- Add categorias_ocultas column
+ALTER TABLE finanzas.preferencias_usuario
+ADD COLUMN IF NOT EXISTS categorias_ocultas JSONB NOT NULL DEFAULT '[]';
+
+-- Add fuentes_ocultas column
+ALTER TABLE finanzas.preferencias_usuario
+ADD COLUMN IF NOT EXISTS fuentes_ocultas JSONB NOT NULL DEFAULT '[]';
+
+-- Add comments
+COMMENT ON COLUMN finanzas.preferencias_usuario.categorias_ocultas IS 'IDs de categorias del sistema que el usuario quiere ocultar';
+COMMENT ON COLUMN finanzas.preferencias_usuario.fuentes_ocultas IS 'IDs de fuentes de ingreso del sistema que el usuario quiere ocultar';

--- a/src/controllers/api/catalogo.controller.js
+++ b/src/controllers/api/catalogo.controller.js
@@ -1,19 +1,48 @@
 import { CategoriaGasto, ImportanciaGasto, TipoPago, FrecuenciaGasto, FuenteIngreso } from '../../models/index.js';
 import { sendSuccess, sendError } from '../../utils/responseHelper.js';
 import logger from '../../utils/logger.js';
+import { Op } from 'sequelize';
+import { getOrCreatePreferencias } from '../../services/preferenciasUsuario.service.js';
 
 /**
  * Controller for catalog data (categorias, importancias, tipos_pago, frecuencias)
  * These are read-only endpoints that return reference data for forms
+ * Filters out hidden categories/fuentes based on user preferences
  */
 
 // GET /api/catalogos/categorias
 export const obtenerCategorias = async (req, res) => {
   try {
+    const usuarioId = req.user.id;
+
+    // Get user preferences to know which system categories are hidden
+    const preferencias = await getOrCreatePreferencias(usuarioId);
+    const categoriasOcultas = preferencias.categorias_ocultas || [];
+
+    // Get system categories + user's personal categories (only active)
     const categorias = await CategoriaGasto.findAll({
-      order: [['id', 'ASC']]
+      where: {
+        [Op.or]: [
+          { es_sistema: true },
+          { usuario_id: usuarioId, activo: true }
+        ]
+      },
+      order: [
+        ['es_sistema', 'DESC'],
+        ['orden', 'ASC'],
+        ['id', 'ASC']
+      ]
     });
-    return sendSuccess(res, categorias);
+
+    // Filter out hidden system categories
+    const resultado = categorias.filter(cat => {
+      if (cat.es_sistema) {
+        return !categoriasOcultas.includes(cat.id);
+      }
+      return true; // Personal categories are already filtered by activo
+    });
+
+    return sendSuccess(res, resultado);
   } catch (error) {
     logger.error('Error al obtener categorías:', { error });
     return sendError(res, 500, 'Error al obtener categorías', error.message);
@@ -62,10 +91,36 @@ export const obtenerFrecuencias = async (req, res) => {
 // GET /api/catalogos/fuentes-ingreso
 export const obtenerFuentesIngreso = async (req, res) => {
   try {
+    const usuarioId = req.user.id;
+
+    // Get user preferences to know which system fuentes are hidden
+    const preferencias = await getOrCreatePreferencias(usuarioId);
+    const fuentesOcultas = preferencias.fuentes_ocultas || [];
+
+    // Get system fuentes + user's personal fuentes (only active)
     const fuentesIngreso = await FuenteIngreso.findAll({
-      order: [['id', 'ASC']]
+      where: {
+        [Op.or]: [
+          { es_sistema: true },
+          { usuario_id: usuarioId, activo: true }
+        ]
+      },
+      order: [
+        ['es_sistema', 'DESC'],
+        ['orden', 'ASC'],
+        ['id', 'ASC']
+      ]
     });
-    return sendSuccess(res, fuentesIngreso);
+
+    // Filter out hidden system fuentes
+    const resultado = fuentesIngreso.filter(fuente => {
+      if (fuente.es_sistema) {
+        return !fuentesOcultas.includes(fuente.id);
+      }
+      return true; // Personal fuentes are already filtered by activo
+    });
+
+    return sendSuccess(res, resultado);
   } catch (error) {
     logger.error('Error al obtener fuentes de ingreso:', { error });
     return sendError(res, 500, 'Error al obtener fuentes de ingreso', error.message);
@@ -75,13 +130,44 @@ export const obtenerFuentesIngreso = async (req, res) => {
 // GET /api/catalogos - Returns all catalogs in a single request
 export const obtenerTodosCatalogos = async (req, res) => {
   try {
-    const [categorias, importancias, tiposPago, frecuencias, fuentesIngreso] = await Promise.all([
-      CategoriaGasto.findAll({ order: [['id', 'ASC']] }),
+    const usuarioId = req.user.id;
+
+    // Get user preferences for hidden items
+    const preferencias = await getOrCreatePreferencias(usuarioId);
+    const categoriasOcultas = preferencias.categorias_ocultas || [];
+    const fuentesOcultas = preferencias.fuentes_ocultas || [];
+
+    const [categoriasRaw, importancias, tiposPago, frecuencias, fuentesRaw] = await Promise.all([
+      CategoriaGasto.findAll({
+        where: {
+          [Op.or]: [
+            { es_sistema: true },
+            { usuario_id: usuarioId, activo: true }
+          ]
+        },
+        order: [['es_sistema', 'DESC'], ['orden', 'ASC'], ['id', 'ASC']]
+      }),
       ImportanciaGasto.findAll({ order: [['id', 'ASC']] }),
       TipoPago.findAll({ order: [['id', 'ASC']] }),
       FrecuenciaGasto.findAll({ order: [['id', 'ASC']] }),
-      FuenteIngreso.findAll({ order: [['id', 'ASC']] })
+      FuenteIngreso.findAll({
+        where: {
+          [Op.or]: [
+            { es_sistema: true },
+            { usuario_id: usuarioId, activo: true }
+          ]
+        },
+        order: [['es_sistema', 'DESC'], ['orden', 'ASC'], ['id', 'ASC']]
+      })
     ]);
+
+    // Filter out hidden system items
+    const categorias = categoriasRaw.filter(cat =>
+      !cat.es_sistema || !categoriasOcultas.includes(cat.id)
+    );
+    const fuentesIngreso = fuentesRaw.filter(fuente =>
+      !fuente.es_sistema || !fuentesOcultas.includes(fuente.id)
+    );
 
     return sendSuccess(res, {
       categorias,

--- a/src/controllers/api/categoria.controller.js
+++ b/src/controllers/api/categoria.controller.js
@@ -2,6 +2,7 @@ import { CategoriaGasto, Gasto, GastoUnico, GastoRecurrente, DebitoAutomatico, C
 import { sendSuccess, sendError } from '../../utils/responseHelper.js';
 import logger from '../../utils/logger.js';
 import { Op } from 'sequelize';
+import { getOrCreatePreferencias, toggleCategoriaVisibilidad } from '../../services/preferenciasUsuario.service.js';
 
 /**
  * Controller for user-customizable categories
@@ -15,6 +16,10 @@ export const obtenerCategorias = async (req, res) => {
     const usuarioId = req.user.id;
     const { includeInactive } = req.query;
 
+    // Get user preferences to know which system categories are hidden
+    const preferencias = await getOrCreatePreferencias(usuarioId);
+    const categoriasOcultas = preferencias.categorias_ocultas || [];
+
     const whereClause = {
       [Op.or]: [
         { es_sistema: true },
@@ -22,9 +27,13 @@ export const obtenerCategorias = async (req, res) => {
       ]
     };
 
-    // By default, only show active categories
+    // By default, only show active categories (for personal categories)
+    // System categories use the preferencias-based visibility
     if (includeInactive !== 'true') {
-      whereClause.activo = true;
+      whereClause[Op.or] = [
+        { es_sistema: true }, // Always include system categories (we'll add visibility field)
+        { usuario_id: usuarioId, activo: true }
+      ];
     }
 
     const categorias = await CategoriaGasto.findAll({
@@ -36,7 +45,25 @@ export const obtenerCategorias = async (req, res) => {
       ]
     });
 
-    return sendSuccess(res, categorias);
+    // Add visibility info to each category
+    const categoriasConVisibilidad = categorias.map(cat => {
+      const catData = cat.toJSON();
+      if (cat.es_sistema) {
+        // For system categories, visibility is based on user preferences
+        catData.visible = !categoriasOcultas.includes(cat.id);
+      } else {
+        // For personal categories, visibility equals activo
+        catData.visible = cat.activo;
+      }
+      return catData;
+    });
+
+    // If not including inactive, filter out hidden system categories
+    const resultado = includeInactive === 'true'
+      ? categoriasConVisibilidad
+      : categoriasConVisibilidad.filter(cat => cat.visible);
+
+    return sendSuccess(res, resultado);
   } catch (error) {
     logger.error('Error al obtener categorías:', { error });
     return sendError(res, 500, 'Error al obtener categorías', error.message);
@@ -175,31 +202,37 @@ export const actualizarCategoria = async (req, res) => {
   }
 };
 
-// PATCH /api/categorias/:id/toggle-activo - Toggle active status
+// PATCH /api/categorias/:id/toggle-activo - Toggle active/visibility status
 export const toggleActivo = async (req, res) => {
   try {
     const usuarioId = req.user.id;
     const { id } = req.params;
+    const categoriaId = parseInt(id, 10);
 
-    const categoria = await CategoriaGasto.findByPk(id);
+    const categoria = await CategoriaGasto.findByPk(categoriaId);
 
     if (!categoria) {
       return sendError(res, 404, 'Categoría no encontrada');
     }
 
-    // Can't toggle system categories
+    // For system categories, toggle visibility in user preferences
     if (categoria.es_sistema) {
-      return sendError(res, 403, 'No se pueden modificar categorías del sistema');
+      const { visible } = await toggleCategoriaVisibilidad(usuarioId, categoriaId);
+      const catData = categoria.toJSON();
+      catData.visible = visible;
+      return sendSuccess(res, catData);
     }
 
-    // Can only toggle own categories
+    // For personal categories, can only toggle own categories
     if (categoria.usuario_id !== usuarioId) {
       return sendError(res, 403, 'No tienes permiso para modificar esta categoría');
     }
 
     await categoria.update({ activo: !categoria.activo });
+    const catData = categoria.toJSON();
+    catData.visible = categoria.activo;
 
-    return sendSuccess(res, categoria);
+    return sendSuccess(res, catData);
   } catch (error) {
     logger.error('Error al cambiar estado de categoría:', { error });
     return sendError(res, 500, 'Error al cambiar estado de categoría', error.message);

--- a/src/controllers/api/fuenteIngreso.controller.js
+++ b/src/controllers/api/fuenteIngreso.controller.js
@@ -2,6 +2,7 @@ import { FuenteIngreso, IngresoUnico, IngresoRecurrente } from '../../models/ind
 import { sendSuccess, sendError } from '../../utils/responseHelper.js';
 import logger from '../../utils/logger.js';
 import { Op } from 'sequelize';
+import { getOrCreatePreferencias, toggleFuenteVisibilidad } from '../../services/preferenciasUsuario.service.js';
 
 /**
  * Controller for user-customizable income sources
@@ -15,6 +16,10 @@ export const obtenerFuentesIngreso = async (req, res) => {
     const usuarioId = req.user.id;
     const { includeInactive } = req.query;
 
+    // Get user preferences to know which system fuentes are hidden
+    const preferencias = await getOrCreatePreferencias(usuarioId);
+    const fuentesOcultas = preferencias.fuentes_ocultas || [];
+
     const whereClause = {
       [Op.or]: [
         { es_sistema: true },
@@ -22,9 +27,13 @@ export const obtenerFuentesIngreso = async (req, res) => {
       ]
     };
 
-    // By default, only show active sources
+    // By default, only show active sources (for personal fuentes)
+    // System fuentes use the preferencias-based visibility
     if (includeInactive !== 'true') {
-      whereClause.activo = true;
+      whereClause[Op.or] = [
+        { es_sistema: true }, // Always include system fuentes (we'll add visibility field)
+        { usuario_id: usuarioId, activo: true }
+      ];
     }
 
     const fuentes = await FuenteIngreso.findAll({
@@ -36,7 +45,25 @@ export const obtenerFuentesIngreso = async (req, res) => {
       ]
     });
 
-    return sendSuccess(res, fuentes);
+    // Add visibility info to each fuente
+    const fuentesConVisibilidad = fuentes.map(fuente => {
+      const fuenteData = fuente.toJSON();
+      if (fuente.es_sistema) {
+        // For system fuentes, visibility is based on user preferences
+        fuenteData.visible = !fuentesOcultas.includes(fuente.id);
+      } else {
+        // For personal fuentes, visibility equals activo
+        fuenteData.visible = fuente.activo;
+      }
+      return fuenteData;
+    });
+
+    // If not including inactive, filter out hidden system fuentes
+    const resultado = includeInactive === 'true'
+      ? fuentesConVisibilidad
+      : fuentesConVisibilidad.filter(f => f.visible);
+
+    return sendSuccess(res, resultado);
   } catch (error) {
     logger.error('Error al obtener fuentes de ingreso:', { error });
     return sendError(res, 500, 'Error al obtener fuentes de ingreso', error.message);
@@ -175,31 +202,37 @@ export const actualizarFuenteIngreso = async (req, res) => {
   }
 };
 
-// PATCH /api/fuentes-ingreso/:id/toggle-activo - Toggle active status
+// PATCH /api/fuentes-ingreso/:id/toggle-activo - Toggle active/visibility status
 export const toggleActivo = async (req, res) => {
   try {
     const usuarioId = req.user.id;
     const { id } = req.params;
+    const fuenteId = parseInt(id, 10);
 
-    const fuente = await FuenteIngreso.findByPk(id);
+    const fuente = await FuenteIngreso.findByPk(fuenteId);
 
     if (!fuente) {
       return sendError(res, 404, 'Fuente de ingreso no encontrada');
     }
 
-    // Can't toggle system sources
+    // For system fuentes, toggle visibility in user preferences
     if (fuente.es_sistema) {
-      return sendError(res, 403, 'No se pueden modificar fuentes del sistema');
+      const { visible } = await toggleFuenteVisibilidad(usuarioId, fuenteId);
+      const fuenteData = fuente.toJSON();
+      fuenteData.visible = visible;
+      return sendSuccess(res, fuenteData);
     }
 
-    // Can only toggle own sources
+    // For personal fuentes, can only toggle own fuentes
     if (fuente.usuario_id !== usuarioId) {
       return sendError(res, 403, 'No tienes permiso para modificar esta fuente');
     }
 
     await fuente.update({ activo: !fuente.activo });
+    const fuenteData = fuente.toJSON();
+    fuenteData.visible = fuente.activo;
 
-    return sendSuccess(res, fuente);
+    return sendSuccess(res, fuenteData);
   } catch (error) {
     logger.error('Error al cambiar estado de fuente:', { error });
     return sendError(res, 500, 'Error al cambiar estado de fuente', error.message);

--- a/src/models/PreferenciasUsuario.model.js
+++ b/src/models/PreferenciasUsuario.model.js
@@ -53,6 +53,18 @@ export function definePreferenciasUsuario(sequelize) {
       validate: {
         isIn: [['light', 'dark', 'system']]
       }
+    },
+    categorias_ocultas: {
+      type: DataTypes.JSONB,
+      allowNull: false,
+      defaultValue: [],
+      comment: 'IDs de categorias del sistema que el usuario quiere ocultar'
+    },
+    fuentes_ocultas: {
+      type: DataTypes.JSONB,
+      allowNull: false,
+      defaultValue: [],
+      comment: 'IDs de fuentes de ingreso del sistema que el usuario quiere ocultar'
     }
   }, {
     tableName: 'preferencias_usuario',

--- a/src/services/preferenciasUsuario.service.js
+++ b/src/services/preferenciasUsuario.service.js
@@ -131,11 +131,95 @@ export async function isModuloActivo(usuarioId, modulo) {
   return preferencias.modulos_activos.includes(modulo);
 }
 
+/**
+ * Toggle visibility of a system category for a user
+ * @param {number} usuarioId - User ID
+ * @param {number} categoriaId - Category ID
+ * @returns {Promise<{visible: boolean, preferencias: PreferenciasUsuario}>}
+ */
+export async function toggleCategoriaVisibilidad(usuarioId, categoriaId) {
+  const preferencias = await getOrCreatePreferencias(usuarioId);
+  let categoriasOcultas = [...(preferencias.categorias_ocultas || [])];
+
+  const isCurrentlyHidden = categoriasOcultas.includes(categoriaId);
+
+  if (isCurrentlyHidden) {
+    // Remove from hidden list (make visible)
+    categoriasOcultas = categoriasOcultas.filter(id => id !== categoriaId);
+  } else {
+    // Add to hidden list
+    categoriasOcultas.push(categoriaId);
+  }
+
+  await preferencias.update({ categorias_ocultas: categoriasOcultas });
+
+  return {
+    visible: isCurrentlyHidden, // If it was hidden, now it's visible
+    preferencias
+  };
+}
+
+/**
+ * Toggle visibility of a system income source for a user
+ * @param {number} usuarioId - User ID
+ * @param {number} fuenteId - Income source ID
+ * @returns {Promise<{visible: boolean, preferencias: PreferenciasUsuario}>}
+ */
+export async function toggleFuenteVisibilidad(usuarioId, fuenteId) {
+  const preferencias = await getOrCreatePreferencias(usuarioId);
+  let fuentesOcultas = [...(preferencias.fuentes_ocultas || [])];
+
+  const isCurrentlyHidden = fuentesOcultas.includes(fuenteId);
+
+  if (isCurrentlyHidden) {
+    // Remove from hidden list (make visible)
+    fuentesOcultas = fuentesOcultas.filter(id => id !== fuenteId);
+  } else {
+    // Add to hidden list
+    fuentesOcultas.push(fuenteId);
+  }
+
+  await preferencias.update({ fuentes_ocultas: fuentesOcultas });
+
+  return {
+    visible: isCurrentlyHidden, // If it was hidden, now it's visible
+    preferencias
+  };
+}
+
+/**
+ * Check if a category is visible for a user
+ * @param {number} usuarioId - User ID
+ * @param {number} categoriaId - Category ID
+ * @returns {Promise<boolean>}
+ */
+export async function isCategoriaVisible(usuarioId, categoriaId) {
+  const preferencias = await getOrCreatePreferencias(usuarioId);
+  const categoriasOcultas = preferencias.categorias_ocultas || [];
+  return !categoriasOcultas.includes(categoriaId);
+}
+
+/**
+ * Check if an income source is visible for a user
+ * @param {number} usuarioId - User ID
+ * @param {number} fuenteId - Income source ID
+ * @returns {Promise<boolean>}
+ */
+export async function isFuenteVisible(usuarioId, fuenteId) {
+  const preferencias = await getOrCreatePreferencias(usuarioId);
+  const fuentesOcultas = preferencias.fuentes_ocultas || [];
+  return !fuentesOcultas.includes(fuenteId);
+}
+
 export default {
   getOrCreatePreferencias,
   getPreferencias,
   updatePreferencias,
   toggleModulo,
   getModulosConEstado,
-  isModuloActivo
+  isModuloActivo,
+  toggleCategoriaVisibilidad,
+  toggleFuenteVisibilidad,
+  isCategoriaVisible,
+  isFuenteVisible
 };


### PR DESCRIPTION
## Summary
- Users can now hide/show system categories and income sources from their view
- System categories/fuentes are shared across all users, so visibility is stored per-user in preferencias_usuario
- Personal (non-system) categories/fuentes continue to use the `activo` field directly

## Changes
- Added `categorias_ocultas` and `fuentes_ocultas` JSONB fields to `preferencias_usuario` table
- Updated `toggleActivo` endpoint for both categories and fuentes controllers to handle system items via preferences
- Added `toggleCategoriaVisibilidad` and `toggleFuenteVisibilidad` functions to preferencias service
- GET endpoints now return a `visible` field indicating visibility based on user preferences or activo status
- Added migration 021_add_categorias_fuentes_ocultas.sql

## Test plan
- [ ] Login as a user
- [ ] Go to Configuracion > Categorias
- [ ] Click the eye icon on a system category (marked "Sistema")
- [ ] Verify the category shows "Oculta" badge
- [ ] Refresh page and verify it stays hidden
- [ ] Click eye again to show it
- [ ] Repeat for Fuentes de Ingreso tab
- [ ] Verify the hidden categories/fuentes don't appear in dropdowns (gastos/ingresos forms)

🤖 Generated with [Claude Code](https://claude.com/claude-code)