### PR TITLE
fix: correct installment generation bug and add catch-up

### DIFF
--- a/src/services/compras.service.js
+++ b/src/services/compras.service.js
@@ -199,7 +199,12 @@ export class ComprasService extends BaseService {
    * Used by the scheduler service
    * @param {number|null} userId - ID del usuario para filtrar (null = todos los usuarios)
    */
-  async findReadyForGeneration(userId = null) {
+  /**
+   * Find purchases that should generate installments today
+   * @param {number|null} userId - ID del usuario para filtrar (null = todos los usuarios)
+   * @param {boolean} allowCatchUp - Si true, incluye cuotas cuya fecha ya pasó (para generación manual)
+   */
+  async findReadyForGeneration(userId = null, allowCatchUp = false) {
     // Build where clause with optional user filter
     const whereClause = { pendiente_cuotas: true };
     if (userId) {
@@ -210,7 +215,7 @@ export class ComprasService extends BaseService {
     const readyPurchases = [];
 
     for (const purchase of pendingPurchases) {
-      const shouldGenerate = await this.installmentStrategy.shouldGenerate(purchase);
+      const shouldGenerate = await this.installmentStrategy.shouldGenerate(purchase, allowCatchUp);
       if (shouldGenerate) {
         readyPurchases.push(purchase);
       }
@@ -531,7 +536,7 @@ export class ComprasService extends BaseService {
         }
       } else {
         // For non-credit card payments, calculate regular schedule
-        const fechaCompra = moment(compra.fecha);
+        const fechaCompra = moment(compra.fecha_compra);
         for (let i = cuotasGeneradas; i < totalCuotas; i++) {
           const fechaCuota = moment(fechaCompra).add(i, 'months');
           scheduleInfo.upcoming_dates.push({

--- a/src/services/creditCardDate.service.js
+++ b/src/services/creditCardDate.service.js
@@ -28,7 +28,7 @@ export class CreditCardDateService {
       throw new Error('La tarjeta de crédito debe tener configurados los días de cierre y vencimiento');
     }
 
-    const fechaCompra = moment(compra.fecha).tz(this.TIMEZONE);
+    const fechaCompra = moment(compra.fecha_compra).tz(this.TIMEZONE);
     const referencia = fechaReferencia ? moment(fechaReferencia).tz(this.TIMEZONE) : moment().tz(this.TIMEZONE);
 
     // Para la primera cuota, calcular basado en el ciclo de la tarjeta
@@ -186,6 +186,40 @@ export class CreditCardDateService {
       return esHoy;
     } catch (error) {
       logger.error('Error al verificar día de vencimiento:', {
+        error: error.message,
+        compra_id: compra.id,
+        cuotaNumero
+      });
+      return false;
+    }
+  }
+
+  /**
+   * Verifica si la fecha de vencimiento ya pasó o es hoy (para catch-up manual)
+   * @param {Object} compra - La compra
+   * @param {Object} tarjeta - La tarjeta de crédito
+   * @param {number} cuotaNumero - Número de cuota
+   * @param {moment.Moment} fechaHoy - Fecha actual (opcional)
+   * @returns {boolean} True si la fecha de vencimiento ya pasó o es hoy
+   */
+  static isDueDateTodayOrPassed(compra, tarjeta, cuotaNumero = 0, fechaHoy = null) {
+    try {
+      const hoy = fechaHoy ? moment(fechaHoy).tz(this.TIMEZONE) : moment().tz(this.TIMEZONE);
+      const fechaVencimiento = this.calculateDueDate(compra, tarjeta, cuotaNumero, hoy);
+
+      const yaPasoOEsHoy = hoy.isSameOrAfter(fechaVencimiento, 'day');
+
+      logger.debug('Verificando si fecha de vencimiento ya pasó o es hoy (catch-up):', {
+        compra_id: compra.id,
+        cuotaNumero,
+        fechaHoy: hoy.format('YYYY-MM-DD'),
+        fechaVencimiento: fechaVencimiento.format('YYYY-MM-DD'),
+        yaPasoOEsHoy
+      });
+
+      return yaPasoOEsHoy;
+    } catch (error) {
+      logger.error('Error al verificar fecha de vencimiento (catch-up):', {
         error: error.message,
         compra_id: compra.id,
         cuotaNumero

--- a/src/services/gastoGenerator.service.js
+++ b/src/services/gastoGenerator.service.js
@@ -129,6 +129,9 @@ export class GastoGeneratorService {
   /**
    * Genera un gasto real desde una compra (cuotas)
    * Usa InstallmentExpenseStrategy
+   *
+   * IMPORTANT: Like other generators, this is called AFTER findReadyForGeneration
+   * has already filtered purchases, so we skip shouldGenerate to ensure catch-up works.
    */
   static async generateFromCompra(compra) {
     const transaction = await sequelize.transaction();
@@ -147,22 +150,21 @@ export class GastoGeneratorService {
 
       const installmentStrategy = new InstallmentExpenseStrategy();
 
-      // Verificar si debe generar cuota hoy
-      const shouldGenerate = await installmentStrategy.shouldGenerate(compra);
-      if (!shouldGenerate) {
-        await transaction.rollback();
-        return null;
-      }
+      // NOTE: We skip shouldGenerate check because findReadyForGeneration
+      // already filtered purchases. This ensures catch-up logic works correctly.
 
       // Generar el gasto usando la estrategia
       const gasto = await installmentStrategy.generate(compra, transaction);
 
       await transaction.commit();
-      logger.info('Gasto generado desde compra con estrategia:', {
-        gasto_id: gasto.id,
-        compra_id: compra.id,
-        monto: gasto.monto_ars
-      });
+
+      if (gasto) {
+        logger.info('Gasto generado desde compra con estrategia:', {
+          gasto_id: gasto.id,
+          compra_id: compra.id,
+          monto: gasto.monto_ars
+        });
+      }
       return gasto;
     } catch (error) {
       await transaction.rollback();
@@ -190,8 +192,9 @@ export class GastoGeneratorService {
    * Los gastos únicos se procesan inmediatamente al crearlos
    * Usado por el scheduler automático con procesamiento optimizado
    * @param {number|null} userId - ID del usuario para filtrar gastos (null = todos los usuarios, para scheduler)
+   * @param {boolean} allowCatchUp - Si true, genera cuotas cuya fecha ya pasó (para generación manual)
    */
-  static async generateScheduledExpenses(userId = null) {
+  static async generateScheduledExpenses(userId = null, allowCatchUp = false) {
     const startTime = Date.now();
     const results = {
       success: [],
@@ -247,7 +250,7 @@ export class GastoGeneratorService {
       );
 
       // Process installment purchases with improved logging
-      const compras = await this.comprasService.findReadyForGeneration(userId);
+      const compras = await this.comprasService.findReadyForGeneration(userId, allowCatchUp);
       results.summary.breakdown.compras.processed = compras.length;
 
       logger.debug('Processing installment purchases', {
@@ -393,7 +396,8 @@ export class GastoGeneratorService {
 
     try {
       // Generar gastos programados (recurrentes, débitos, compras)
-      const scheduledResults = await this.generateScheduledExpenses(userId);
+      // allowCatchUp: true para que genere cuotas atrasadas al ejecutar manualmente
+      const scheduledResults = await this.generateScheduledExpenses(userId, true);
       results.success.push(...scheduledResults.success);
       results.errors.push(...scheduledResults.errors);
 

--- a/src/strategies/expenseGeneration/installmentStrategy.js
+++ b/src/strategies/expenseGeneration/installmentStrategy.js
@@ -23,7 +23,9 @@ import logger from '../../utils/logger.js';
  */
 export class InstallmentExpenseStrategy extends BaseExpenseGenerationStrategy {
   async generate(compra, transaction = null) {
-    if (!this.validateSource(compra) || !await this.shouldGenerate(compra)) {
+    // Only validate source structure, skip shouldGenerate check.
+    // shouldGenerate is already called by findReadyForGeneration upstream.
+    if (!this.validateSource(compra)) {
       return null;
     }
 
@@ -73,7 +75,11 @@ export class InstallmentExpenseStrategy extends BaseExpenseGenerationStrategy {
     }
   }
 
-  async shouldGenerate(compra) {
+  /**
+   * @param {Object} compra - La compra
+   * @param {boolean} allowCatchUp - Si true, genera cuotas cuya fecha de vencimiento ya pasó (para generación manual)
+   */
+  async shouldGenerate(compra, allowCatchUp = false) {
     if (!compra.pendiente_cuotas) {
       return false;
     }
@@ -89,17 +95,17 @@ export class InstallmentExpenseStrategy extends BaseExpenseGenerationStrategy {
 
     // Para cuota única
     if (totalCuotas === 1) {
-      return this.shouldGenerateSingleInstallment(compra, today);
+      return this.shouldGenerateSingleInstallment(compra, today, allowCatchUp);
     }
 
     // Para múltiples cuotas
-    return this.shouldGenerateMultipleInstallment(compra, today, cuotasGeneradas);
+    return this.shouldGenerateMultipleInstallment(compra, today, cuotasGeneradas, allowCatchUp);
   }
 
   /**
    * Verifica si debe generar una cuota única
    */
-  shouldGenerateSingleInstallment(compra, today) {
+  shouldGenerateSingleInstallment(compra, today, allowCatchUp = false) {
     // Si ya se generó, no generar de nuevo
     if (compra.fecha_ultima_cuota_generada) {
       return false;
@@ -107,7 +113,7 @@ export class InstallmentExpenseStrategy extends BaseExpenseGenerationStrategy {
 
     // Si es tarjeta de crédito, verificar día de vencimiento
     if (this.isCreditCardPayment(compra)) {
-      return this.shouldGenerateOnCreditCardDueDate(compra, today);
+      return this.shouldGenerateOnCreditCardDueDate(compra, today, 0, allowCatchUp);
     }
 
     // Para otros medios de pago (efectivo, débito, transferencia)
@@ -128,7 +134,7 @@ export class InstallmentExpenseStrategy extends BaseExpenseGenerationStrategy {
    *   - Efectivo/Débito/Transferencia: Generar el mismo día del mes de la compra
    *   - Tarjeta de Crédito: Generar en día de vencimiento de la tarjeta
    */
-  shouldGenerateMultipleInstallment(compra, today, cuotasGeneradas) {
+  shouldGenerateMultipleInstallment(compra, today, cuotasGeneradas, allowCatchUp = false) {
     // Verificar que no se haya generado cuota este mes
     if (compra.fecha_ultima_cuota_generada) {
       const ultimaCuota = moment(compra.fecha_ultima_cuota_generada);
@@ -139,7 +145,7 @@ export class InstallmentExpenseStrategy extends BaseExpenseGenerationStrategy {
 
     // Si es tarjeta de crédito, siempre usar día de vencimiento
     if (this.isCreditCardPayment(compra)) {
-      return this.shouldGenerateOnCreditCardDueDate(compra, today, cuotasGeneradas);
+      return this.shouldGenerateOnCreditCardDueDate(compra, today, cuotasGeneradas, allowCatchUp);
     }
 
     // Para otros medios de pago (efectivo, débito, transferencia):
@@ -151,6 +157,10 @@ export class InstallmentExpenseStrategy extends BaseExpenseGenerationStrategy {
     }
 
     // Cuotas siguientes: mismo día del mes que la fecha de compra
+    // Con catch-up: también generar si ya pasó el día este mes
+    if (allowCatchUp) {
+      return today.date() >= fechaCompra.date();
+    }
     return today.date() === fechaCompra.date();
   }
 
@@ -166,7 +176,14 @@ export class InstallmentExpenseStrategy extends BaseExpenseGenerationStrategy {
    * Verifica si debe generar en el día de vencimiento de la tarjeta de crédito
    * Utiliza el CreditCardDateService para cálculos inteligentes
    */
-  shouldGenerateOnCreditCardDueDate(compra, today, cuotaNumero = 0) {
+  /**
+   * Verifica si debe generar en el día de vencimiento de la tarjeta de crédito
+   * @param {Object} compra - La compra
+   * @param {moment.Moment} today - Fecha actual
+   * @param {number} cuotaNumero - Número de cuota (0-based)
+   * @param {boolean} allowCatchUp - Si true, también genera si la fecha de vencimiento ya pasó
+   */
+  shouldGenerateOnCreditCardDueDate(compra, today, cuotaNumero = 0, allowCatchUp = false) {
     if (!compra.tarjeta || compra.tarjeta.tipo !== 'credito') {
       logger.error('Tarjeta de crédito inválida o no configurada:', {
         compra_id: compra.id,
@@ -188,24 +205,22 @@ export class InstallmentExpenseStrategy extends BaseExpenseGenerationStrategy {
         return false;
       }
 
-      // Verificar si hoy es día de vencimiento usando el servicio inteligente
-      const esHoyDiaVencimiento = CreditCardDateService.isDueDateToday(
-        compra,
-        compra.tarjeta,
-        cuotaNumero,
-        today
-      );
+      // Verificar si hoy es día de vencimiento (o ya pasó, en modo catch-up)
+      const shouldGenerate = allowCatchUp
+        ? CreditCardDateService.isDueDateTodayOrPassed(compra, compra.tarjeta, cuotaNumero, today)
+        : CreditCardDateService.isDueDateToday(compra, compra.tarjeta, cuotaNumero, today);
 
-      if (esHoyDiaVencimiento) {
-        logger.info('Día de vencimiento detectado para compra:', {
+      if (shouldGenerate) {
+        logger.info(`Día de vencimiento ${allowCatchUp ? '(catch-up) ' : ''}detectado para compra:`, {
           compra_id: compra.id,
           tarjeta_id: compra.tarjeta_id,
           cuotaNumero: cuotaNumero + 1,
-          fecha_hoy: today.format('YYYY-MM-DD')
+          fecha_hoy: today.format('YYYY-MM-DD'),
+          allowCatchUp
         });
       }
 
-      return esHoyDiaVencimiento;
+      return shouldGenerate;
     } catch (error) {
       logger.error('Error al verificar día de vencimiento:', {
         error: error.message,

--- a/tests/unit/services/gastoGenerator.service.test.js
+++ b/tests/unit/services/gastoGenerator.service.test.js
@@ -282,26 +282,24 @@ describe('GastoGeneratorService', () => {
       monto_ars: 500
     };
 
-    it('should generate gasto from compra when shouldGenerate returns true', async () => {
-      mockInstallmentShouldGenerate.mockResolvedValue(true);
+    it('should generate gasto from compra directly (shouldGenerate handled by findReadyForGeneration)', async () => {
       mockInstallmentGenerate.mockResolvedValue(mockGeneratedGasto);
 
       const result = await GastoGeneratorService.generateFromCompra(mockCompra);
 
       expect(result).toEqual(mockGeneratedGasto);
-      expect(mockInstallmentShouldGenerate).toHaveBeenCalledWith(mockCompra);
+      expect(mockInstallmentShouldGenerate).not.toHaveBeenCalled();
       expect(mockInstallmentGenerate).toHaveBeenCalledWith(mockCompra, mockTransaction);
       expect(mockTransaction.commit).toHaveBeenCalled();
     });
 
-    it('should return null when shouldGenerate returns false', async () => {
-      mockInstallmentShouldGenerate.mockResolvedValue(false);
+    it('should handle null result from generate (skipped by strategy)', async () => {
+      mockInstallmentGenerate.mockResolvedValue(null);
 
       const result = await GastoGeneratorService.generateFromCompra(mockCompra);
 
       expect(result).toBeNull();
-      expect(mockInstallmentGenerate).not.toHaveBeenCalled();
-      expect(mockTransaction.rollback).toHaveBeenCalled();
+      expect(mockTransaction.commit).toHaveBeenCalled();
     });
 
     it('should throw error when foreign keys are missing', async () => {
@@ -317,7 +315,6 @@ describe('GastoGeneratorService', () => {
     });
 
     it('should rollback transaction on strategy error', async () => {
-      mockInstallmentShouldGenerate.mockResolvedValue(true);
       mockInstallmentGenerate.mockRejectedValue(new Error('Installment error'));
 
       await expect(GastoGeneratorService.generateFromCompra(mockCompra))
@@ -347,7 +344,7 @@ describe('GastoGeneratorService', () => {
 
       expect(mockFindReadyRecurrentes).toHaveBeenCalledWith(123);
       expect(mockFindReadyDebitos).toHaveBeenCalledWith(123);
-      expect(mockFindReadyCompras).toHaveBeenCalledWith(123);
+      expect(mockFindReadyCompras).toHaveBeenCalledWith(123, false);
     });
 
     it('should include processing time in results', async () => {


### PR DESCRIPTION
## Summary
- **Bug fix**: `CreditCardDateService.calculateDueDate` used `compra.fecha` (undefined) instead of `compra.fecha_compra`, causing `moment(undefined)` to default to today's date. This broke all credit card installment generation since `isDueDateToday` never matched the actual due date. Same bug existed in `compras.service.js` for payment schedule calculation.
- **Catch-up support**: Manual generation (`POST /api/gastos/generar`) now passes `allowCatchUp: true` so installments whose due date already passed (but weren't generated) get recovered. The daily scheduler still only generates on the exact due date.
- **Consistency**: `generateFromCompra` no longer double-checks `shouldGenerate` (already handled by `findReadyForGeneration`), matching the pattern used by recurring and automatic debit generators.

## Test plan
- [x] All 387 existing tests pass
- [ ] Deploy and run `POST /api/gastos/generar` to recover missed March installments
- [ ] Verify next month's scheduler generates installments correctly on due dates

🤖 Generated with [Claude Code](https://claude.com/claude-code)