### PR TITLE
feat: cuotas pagadas en creación de compras + fix fecha tarjeta crédito

### DIFF
--- a/docs/api/swagger.yaml
+++ b/docs/api/swagger.yaml
@@ -2653,6 +2653,13 @@ paths:
                   minimum: 1
                   maximum: 60
                   default: 1
+                cuotas_pagadas:
+                  type: integer
+                  minimum: 0
+                  default: 0
+                  description: >
+                    Número de cuotas ya pagadas (para compras existentes que se cargan retroactivamente).
+                    Debe ser <= cantidad_cuotas. Si es igual a cantidad_cuotas, la compra se marca como completamente pagada.
                 categoria_gasto_id:
                   type: integer
                   minimum: 1
@@ -2669,6 +2676,28 @@ paths:
       responses:
         '201':
           description: Compra creada exitosamente
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  data:
+                    type: object
+                    properties:
+                      compra:
+                        type: object
+                        description: La compra creada con sus relaciones
+                      gasto:
+                        type: object
+                        nullable: true
+                        description: Gasto generado inmediatamente (solo para compras de 1 cuota sin tarjeta de crédito)
+                      gastos_historicos:
+                        type: array
+                        items:
+                          type: object
+                        description: Gastos generados para cuotas ya pagadas (solo cuando cuotas_pagadas > 0)
 
   /compras/{id}:
     get:

--- a/src/controllers/api/compra.controller.js
+++ b/src/controllers/api/compra.controller.js
@@ -8,6 +8,7 @@ import { sendError, sendSuccess, sendPaginatedSuccess, sendValidationError } fro
 import logger from '../../utils/logger.js';
 import { cleanEntityFormData } from '../../utils/formDataHelper.js';
 import { FilterBuilder, buildQueryOptions, buildPagination } from '../../utils/filterBuilder.js';
+import { InstallmentExpenseStrategy } from '../../strategies/expenseGeneration/installmentStrategy.js';
 
 export class CompraController extends BaseController {
   constructor() {
@@ -54,12 +55,17 @@ export class CompraController extends BaseController {
       const montoTotal = req.body.monto_total;
       const monedaOrigen = req.body.moneda_origen || 'ARS';
 
+      const cuotasPagadas = req.body.cuotas_pagadas || 0;
+
       let compraData = {
         ...req.body,
         usuario_id: req.user.id,
         pendiente_cuotas: true,
         moneda_origen: monedaOrigen
       };
+
+      // Eliminar cuotas_pagadas de compraData - no es columna del modelo Compra
+      delete compraData.cuotas_pagadas;
 
       // Calculate monto_total_ars, monto_total_usd, tipo_cambio_usado
       try {
@@ -98,15 +104,51 @@ export class CompraController extends BaseController {
         transaction
       });
 
-      // 3. Intentar generar primer gasto si corresponde (business rule: compras de 1 cuota se generan inmediatamente)
+      // 3. Generar gastos según cuotas_pagadas
       let gasto = null;
-      if (compra.cantidad_cuotas === 1 || compra.cantidad_cuotas === null) {
-        try {
-          gasto = await GastoGeneratorService.generateFromCompra(compraCompleta);
-        } catch (error) {
-          logger.warn('No se pudo generar gasto inmediato para compra:', {
+      let gastosHistoricos = [];
+
+      if (cuotasPagadas > 0) {
+        // Generar gastos históricos para cuotas ya pagadas
+        const installmentStrategy = new InstallmentExpenseStrategy();
+        const result = await installmentStrategy.generateHistoricalInstallments(compraCompleta, cuotasPagadas, transaction);
+        gastosHistoricos = result.gastos;
+
+        // Actualizar estado de la compra
+        const cantidadCuotas = compraCompleta.cantidad_cuotas || 1;
+        const updateData = {
+          fecha_ultima_cuota_generada: result.lastDate
+        };
+
+        if (cuotasPagadas >= cantidadCuotas) {
+          updateData.pendiente_cuotas = false;
+        }
+
+        await compraCompleta.update(updateData, { transaction });
+
+        logger.info('Cuotas históricas generadas:', {
+          compra_id: compra.id,
+          cuotas_pagadas: cuotasPagadas,
+          gastos_generados: gastosHistoricos.length,
+          completamente_pagada: cuotasPagadas >= cantidadCuotas
+        });
+      } else if (compra.cantidad_cuotas === 1 || compra.cantidad_cuotas === null) {
+        // Compras de 1 cuota con tarjeta de crédito: no generar inmediatamente,
+        // el scheduler lo genera cuando llega la fecha de vencimiento de la tarjeta
+        const isCreditCard = compraCompleta.tarjeta_id && compraCompleta.tarjeta?.tipo === 'credito';
+        if (!isCreditCard) {
+          try {
+            gasto = await GastoGeneratorService.generateFromCompra(compraCompleta);
+          } catch (error) {
+            logger.warn('No se pudo generar gasto inmediato para compra:', {
+              compra_id: compra.id,
+              error: error.message
+            });
+          }
+        } else {
+          logger.info('Compra con tarjeta de crédito - gasto se generará en fecha de vencimiento:', {
             compra_id: compra.id,
-            error: error.message
+            tarjeta_id: compraCompleta.tarjeta_id
           });
         }
       }
@@ -116,10 +158,15 @@ export class CompraController extends BaseController {
         compra_id: compra.id,
         gasto_id: gasto?.id,
         primera_generacion: !!gasto,
+        cuotas_pagadas: cuotasPagadas,
         es_cuotas: compra.cantidad_cuotas > 1
       });
 
-      return sendSuccess(res, { compra: compraCompleta, gasto }, 201);
+      return sendSuccess(res, {
+        compra: compraCompleta,
+        gasto,
+        gastos_historicos: gastosHistoricos.length > 0 ? gastosHistoricos : undefined
+      }, 201);
     } catch (error) {
       await transaction.rollback();
       logger.error('Error al crear compra:', { error });
@@ -235,6 +282,17 @@ export class CompraController extends BaseController {
         isValid: false,
         message: 'La fecha de compra no puede ser futura'
       };
+    }
+
+    // Validar cuotas pagadas vs cantidad de cuotas
+    if (data.cuotas_pagadas > 0) {
+      const cantidadCuotas = data.cantidad_cuotas || 1;
+      if (data.cuotas_pagadas > cantidadCuotas) {
+        return {
+          isValid: false,
+          message: 'Las cuotas pagadas no pueden superar la cantidad total de cuotas'
+        };
+      }
     }
 
     return { isValid: true };

--- a/src/middlewares/validation.middleware.js
+++ b/src/middlewares/validation.middleware.js
@@ -77,6 +77,12 @@ const compraSchema = Joi.object({
       'number.min': 'La cantidad de cuotas debe ser al menos 1',
       'number.max': 'La cantidad de cuotas no puede exceder 60'
     }),
+  cuotas_pagadas: Joi.number().integer().min(0).default(0)
+    .messages({
+      'number.base': 'Las cuotas pagadas deben ser un número',
+      'number.integer': 'Las cuotas pagadas deben ser un número entero',
+      'number.min': 'Las cuotas pagadas no pueden ser negativas'
+    }),
   // 💱 Multi-currency fields
   moneda_origen: Joi.string().valid('ARS', 'USD').default('ARS'),
   monto_total_ars: Joi.forbidden(),

--- a/src/strategies/expenseGeneration/installmentStrategy.js
+++ b/src/strategies/expenseGeneration/installmentStrategy.js
@@ -31,10 +31,20 @@ export class InstallmentExpenseStrategy extends BaseExpenseGenerationStrategy {
 
     try {
       const today = moment().tz('America/Argentina/Buenos_Aires');
-      const fechaParaBD = today.format('YYYY-MM-DD');
 
       // Calcular cuál cuota corresponde
       const cuotaActual = await this.calculateCurrentInstallment(compra);
+
+      // Calcular fecha: tarjeta de crédito usa fecha de vencimiento, otros usan hoy
+      let fechaParaBD;
+      const isCreditCard = compra.tarjeta_id && compra.tarjeta?.tipo === 'credito';
+      if (isCreditCard) {
+        const cuotaNumero0Based = cuotaActual - 1;
+        const fechaVencimiento = CreditCardDateService.calculateDueDate(compra, compra.tarjeta, cuotaNumero0Based);
+        fechaParaBD = fechaVencimiento.format('YYYY-MM-DD');
+      } else {
+        fechaParaBD = today.format('YYYY-MM-DD');
+      }
 
       // 💱 Calculate installment amount in both currencies
       const { montoCuotaARS, montoCuotaUSD } = await this.calculateInstallmentAmountMultiCurrency(compra);
@@ -299,6 +309,54 @@ export class InstallmentExpenseStrategy extends BaseExpenseGenerationStrategy {
     }
 
     await compra.update(updateData, { transaction });
+  }
+
+  /**
+   * Genera gastos históricos para cuotas ya pagadas al crear una compra.
+   * Reutiliza calculateInstallmentAmountMultiCurrency y createGastoData.
+   */
+  async generateHistoricalInstallments(compra, cuotasPagadas, transaction) {
+    const isCreditCard = compra.tarjeta_id && compra.tarjeta?.tipo === 'credito';
+    const cantidadCuotas = compra.cantidad_cuotas || 1;
+    const { montoCuotaARS, montoCuotaUSD } = await this.calculateInstallmentAmountMultiCurrency(compra);
+
+    const gastos = [];
+    let lastDate = null;
+    const today = moment().tz('America/Argentina/Buenos_Aires');
+
+    for (let i = 0; i < cuotasPagadas; i++) {
+      let fechaMoment;
+
+      if (isCreditCard) {
+        fechaMoment = CreditCardDateService.calculateDueDate(compra, compra.tarjeta, i);
+      } else {
+        const fechaCompra = moment(compra.fecha_compra);
+        fechaMoment = moment(compra.fecha_compra).add(i, 'months');
+        fechaMoment.date(Math.min(fechaCompra.date(), fechaMoment.daysInMonth()));
+      }
+
+      // Cuotas "pagadas" no pueden tener fecha futura
+      if (fechaMoment.isAfter(today, 'day')) {
+        fechaMoment = today.clone();
+      }
+
+      const fecha = fechaMoment.format('YYYY-MM-DD');
+
+      const gastoData = this.createGastoData(compra, {
+        fecha,
+        monto_ars: montoCuotaARS,
+        monto_usd: montoCuotaUSD,
+        moneda_origen: compra.moneda_origen || 'ARS',
+        tipo_cambio_usado: compra.tipo_cambio_usado || null,
+        descripcion: `${compra.descripcion} - Cuota ${i + 1}/${cantidadCuotas}`
+      });
+
+      const gasto = await Gasto.create(gastoData, { transaction });
+      gastos.push(gasto);
+      lastDate = fecha;
+    }
+
+    return { gastos, lastDate };
   }
 
   getType() {

--- a/src/validations/compra.validation.js
+++ b/src/validations/compra.validation.js
@@ -4,6 +4,7 @@ export const createCompraSchema = Joi.object({
   descripcion: Joi.string().trim().min(3).max(255).required(),
   monto_total: Joi.number().positive().precision(2).required(),
   cantidad_cuotas: Joi.number().integer().min(1).max(60).default(1),
+  cuotas_pagadas: Joi.number().integer().min(0).default(0),
   fecha_compra: Joi.date().iso().max('now').required(),
   categoria_gasto_id: Joi.number().integer().positive().required(),
   importancia_gasto_id: Joi.number().integer().positive().required(),

--- a/tests/unit/controllers/compra.cuotasPagadas.test.js
+++ b/tests/unit/controllers/compra.cuotasPagadas.test.js
@@ -1,0 +1,381 @@
+import { describe, it, expect, beforeEach, jest, afterEach } from '@jest/globals';
+
+// Mock sequelize
+const mockTransaction = {
+  commit: jest.fn().mockResolvedValue(),
+  rollback: jest.fn().mockResolvedValue()
+};
+
+jest.unstable_mockModule('../../../src/db/postgres.js', () => ({
+  default: {
+    transaction: jest.fn().mockResolvedValue(mockTransaction)
+  }
+}));
+
+// Mock logger
+jest.unstable_mockModule('../../../src/utils/logger.js', () => ({
+  default: {
+    info: jest.fn(),
+    debug: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn()
+  }
+}));
+
+// Mock Gasto.create
+const mockGastoCreate = jest.fn();
+
+// Mock models
+const mockCompraCreate = jest.fn();
+const mockCompraFindByPk = jest.fn();
+const mockCompraUpdate = jest.fn();
+
+jest.unstable_mockModule('../../../src/models/index.js', () => ({
+  Compra: {
+    create: mockCompraCreate,
+    findByPk: mockCompraFindByPk,
+    findOne: jest.fn(),
+    findAll: jest.fn(),
+    count: jest.fn()
+  },
+  CategoriaGasto: { findByPk: jest.fn().mockResolvedValue({ id: 1 }) },
+  ImportanciaGasto: { findByPk: jest.fn().mockResolvedValue({ id: 1 }) },
+  TipoPago: { findByPk: jest.fn().mockResolvedValue({ id: 1 }) },
+  Tarjeta: { findByPk: jest.fn().mockResolvedValue({ id: 1, tipo: 'credito', dia_mes_cierre: 20, dia_mes_vencimiento: 10 }) },
+  Gasto: {
+    create: mockGastoCreate,
+    findAll: jest.fn().mockResolvedValue([]),
+    count: jest.fn().mockResolvedValue(0)
+  }
+}));
+
+// Mock GastoGeneratorService
+const mockGenerateFromCompra = jest.fn();
+jest.unstable_mockModule('../../../src/services/gastoGenerator.service.js', () => ({
+  GastoGeneratorService: {
+    generateFromCompra: mockGenerateFromCompra
+  }
+}));
+
+// Mock ExchangeRateService
+jest.unstable_mockModule('../../../src/services/exchangeRate.service.js', () => ({
+  ExchangeRateService: {
+    calculateBothCurrencies: jest.fn().mockResolvedValue({
+      monto_ars: 12000,
+      monto_usd: 12,
+      tipo_cambio_usado: 1000
+    })
+  }
+}));
+
+// Mock responseHelper
+const mockSendSuccess = jest.fn();
+const mockSendError = jest.fn();
+const mockSendValidationError = jest.fn();
+jest.unstable_mockModule('../../../src/utils/responseHelper.js', () => ({
+  sendError: mockSendError,
+  sendSuccess: mockSendSuccess,
+  sendPaginatedSuccess: jest.fn(),
+  sendValidationError: mockSendValidationError
+}));
+
+// Mock filterBuilder
+jest.unstable_mockModule('../../../src/utils/filterBuilder.js', () => ({
+  FilterBuilder: class { },
+  buildQueryOptions: jest.fn(),
+  buildPagination: jest.fn()
+}));
+
+// Mock formDataHelper
+jest.unstable_mockModule('../../../src/utils/formDataHelper.js', () => ({
+  cleanEntityFormData: jest.fn((data) => data)
+}));
+
+// Mock base controller validateExistingIds
+jest.unstable_mockModule('../../../src/controllers/api/base.controller.js', () => ({
+  BaseController: class {
+    constructor(model, name) {
+      this.model = model;
+      this.modelName = name;
+    }
+    async validateExistingIds() { return []; }
+  }
+}));
+
+let CompraController;
+let InstallmentExpenseStrategy;
+
+beforeEach(async () => {
+  jest.clearAllMocks();
+  const module = await import('../../../src/controllers/api/compra.controller.js');
+  CompraController = module.CompraController;
+  const strategyModule = await import('../../../src/strategies/expenseGeneration/installmentStrategy.js');
+  InstallmentExpenseStrategy = strategyModule.InstallmentExpenseStrategy;
+});
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+describe('CompraController - cuotas_pagadas', () => {
+  describe('validateCompraFields', () => {
+    let controller;
+
+    beforeEach(() => {
+      controller = new CompraController();
+    });
+
+    it('should pass validation when cuotas_pagadas is 0', () => {
+      const result = controller.validateCompraFields({
+        monto_total: 12000,
+        fecha_compra: '2025-12-15',
+        cantidad_cuotas: 12,
+        cuotas_pagadas: 0
+      });
+      expect(result.isValid).toBe(true);
+    });
+
+    it('should pass validation when cuotas_pagadas < cantidad_cuotas', () => {
+      const result = controller.validateCompraFields({
+        monto_total: 12000,
+        fecha_compra: '2025-12-15',
+        cantidad_cuotas: 12,
+        cuotas_pagadas: 5
+      });
+      expect(result.isValid).toBe(true);
+    });
+
+    it('should pass validation when cuotas_pagadas equals cantidad_cuotas', () => {
+      const result = controller.validateCompraFields({
+        monto_total: 6000,
+        fecha_compra: '2025-10-15',
+        cantidad_cuotas: 6,
+        cuotas_pagadas: 6
+      });
+      expect(result.isValid).toBe(true);
+    });
+
+    it('should fail validation when cuotas_pagadas > cantidad_cuotas', () => {
+      const result = controller.validateCompraFields({
+        monto_total: 6000,
+        fecha_compra: '2025-10-15',
+        cantidad_cuotas: 6,
+        cuotas_pagadas: 7
+      });
+      expect(result.isValid).toBe(false);
+      expect(result.message).toContain('cuotas pagadas no pueden superar');
+    });
+
+    it('should fail when cuotas_pagadas > 1 and cantidad_cuotas defaults to 1', () => {
+      const result = controller.validateCompraFields({
+        monto_total: 1000,
+        fecha_compra: '2025-12-15',
+        cuotas_pagadas: 2
+      });
+      expect(result.isValid).toBe(false);
+    });
+  });
+
+  describe('generateHistoricalInstallments', () => {
+    let strategy;
+
+    beforeEach(() => {
+      strategy = new InstallmentExpenseStrategy();
+      mockGastoCreate.mockImplementation((data) => Promise.resolve({ id: Math.random(), ...data }));
+    });
+
+    it('should generate gastos with monthly dates for non-credit-card purchases', async () => {
+      const compra = {
+        id: 1,
+        descripcion: 'Laptop',
+        monto_total: 6000,
+        monto_total_ars: 6000,
+        monto_total_usd: null,
+        cantidad_cuotas: 6,
+        fecha_compra: '2025-12-15',
+        moneda_origen: 'ARS',
+        tipo_cambio_usado: null,
+        categoria_gasto_id: 1,
+        importancia_gasto_id: 1,
+        tipo_pago_id: 2,
+        tarjeta_id: null,
+        tarjeta: null,
+        usuario_id: 1
+      };
+
+      const result = await strategy.generateHistoricalInstallments(compra, 3, mockTransaction);
+
+      expect(result.gastos).toHaveLength(3);
+      expect(mockGastoCreate).toHaveBeenCalledTimes(3);
+
+      // Verify dates: Dec 15, Jan 15, Feb 15
+      const calls = mockGastoCreate.mock.calls;
+      expect(calls[0][0].fecha).toBe('2025-12-15');
+      expect(calls[1][0].fecha).toBe('2026-01-15');
+      expect(calls[2][0].fecha).toBe('2026-02-15');
+
+      // Verify descriptions
+      expect(calls[0][0].descripcion).toBe('Laptop - Cuota 1/6');
+      expect(calls[1][0].descripcion).toBe('Laptop - Cuota 2/6');
+      expect(calls[2][0].descripcion).toBe('Laptop - Cuota 3/6');
+
+      // Verify amounts (6000 / 6 = 1000)
+      expect(calls[0][0].monto_ars).toBe(1000);
+      expect(calls[0][0].monto_usd).toBeNull();
+
+      // Verify tipo_origen
+      expect(calls[0][0].tipo_origen).toBe('compra');
+      expect(calls[0][0].id_origen).toBe(1);
+
+      // Verify lastDate
+      expect(result.lastDate).toBe('2026-02-15');
+    });
+
+    it('should generate gastos with credit card due dates', async () => {
+      const compra = {
+        id: 2,
+        descripcion: 'TV',
+        monto_total: 12000,
+        monto_total_ars: 12000,
+        monto_total_usd: 12,
+        cantidad_cuotas: 12,
+        fecha_compra: '2025-12-10',
+        moneda_origen: 'ARS',
+        tipo_cambio_usado: 1000,
+        categoria_gasto_id: 1,
+        importancia_gasto_id: 1,
+        tipo_pago_id: 3,
+        tarjeta_id: 1,
+        tarjeta: { tipo: 'credito', dia_mes_cierre: 20, dia_mes_vencimiento: 10 },
+        usuario_id: 1
+      };
+
+      const result = await strategy.generateHistoricalInstallments(compra, 3, mockTransaction);
+
+      expect(result.gastos).toHaveLength(3);
+
+      // Credit card: compra Dec 10, cierre 20, vto 10
+      // Dec 10 <= cierre Dec 20 → first due: Jan 10
+      // Cuota 2: Feb 10, Cuota 3: Mar 10
+      const calls = mockGastoCreate.mock.calls;
+      expect(calls[0][0].fecha).toBe('2026-01-10');
+      expect(calls[1][0].fecha).toBe('2026-02-10');
+      expect(calls[2][0].fecha).toBe('2026-03-10');
+
+      // Verify multi-currency amounts (12000/12=1000 ARS, 12/12=1 USD)
+      expect(calls[0][0].monto_ars).toBe(1000);
+      expect(calls[0][0].monto_usd).toBe(1);
+    });
+
+    it('should handle day clamping for months with fewer days', async () => {
+      const compra = {
+        id: 3,
+        descripcion: 'Compra fin de mes',
+        monto_total: 3000,
+        monto_total_ars: 3000,
+        monto_total_usd: null,
+        cantidad_cuotas: 3,
+        fecha_compra: '2025-10-31',
+        moneda_origen: 'ARS',
+        tipo_cambio_usado: null,
+        categoria_gasto_id: 1,
+        importancia_gasto_id: 1,
+        tipo_pago_id: 2,
+        tarjeta_id: null,
+        tarjeta: null,
+        usuario_id: 1
+      };
+
+      const result = await strategy.generateHistoricalInstallments(compra, 3, mockTransaction);
+
+      const calls = mockGastoCreate.mock.calls;
+      expect(calls[0][0].fecha).toBe('2025-10-31');
+      expect(calls[1][0].fecha).toBe('2025-11-30'); // Nov clamps 31 → 30
+      expect(calls[2][0].fecha).toBe('2025-12-31');
+    });
+
+    it('should handle single installment fully paid', async () => {
+      const compra = {
+        id: 4,
+        descripcion: 'Gasto único',
+        monto_total: 500,
+        monto_total_ars: 500,
+        monto_total_usd: null,
+        cantidad_cuotas: 1,
+        fecha_compra: '2026-03-01',
+        moneda_origen: 'ARS',
+        tipo_cambio_usado: null,
+        categoria_gasto_id: 1,
+        importancia_gasto_id: 1,
+        tipo_pago_id: 1,
+        tarjeta_id: null,
+        tarjeta: null,
+        usuario_id: 1
+      };
+
+      const result = await strategy.generateHistoricalInstallments(compra, 1, mockTransaction);
+
+      expect(result.gastos).toHaveLength(1);
+      const call = mockGastoCreate.mock.calls[0][0];
+      expect(call.descripcion).toBe('Gasto único - Cuota 1/1');
+      expect(call.monto_ars).toBe(500); // Full amount for single cuota
+    });
+
+    it('should clamp future dates to today', async () => {
+      const compra = {
+        id: 6,
+        descripcion: 'Compra reciente',
+        monto_total: 6000,
+        monto_total_ars: 6000,
+        monto_total_usd: null,
+        cantidad_cuotas: 6,
+        fecha_compra: '2026-02-15',
+        moneda_origen: 'ARS',
+        tipo_cambio_usado: null,
+        categoria_gasto_id: 1,
+        importancia_gasto_id: 1,
+        tipo_pago_id: 2,
+        tarjeta_id: null,
+        tarjeta: null,
+        usuario_id: 1
+      };
+
+      // 3 cuotas: Feb 15 (past), Mar 15 (past), Apr 15 (future → clamped)
+      const result = await strategy.generateHistoricalInstallments(compra, 3, mockTransaction);
+
+      const calls = mockGastoCreate.mock.calls;
+      expect(calls[0][0].fecha).toBe('2026-02-15');
+      expect(calls[1][0].fecha).toBe('2026-03-15');
+      // Apr 15 is future, should be clamped to today
+      const moment = (await import('moment-timezone')).default;
+      const today = moment().tz('America/Argentina/Buenos_Aires').format('YYYY-MM-DD');
+      expect(calls[2][0].fecha).toBe(today);
+    });
+
+    it('should pass transaction to all Gasto.create calls', async () => {
+      const compra = {
+        id: 5,
+        descripcion: 'Test',
+        monto_total: 2000,
+        monto_total_ars: 2000,
+        monto_total_usd: null,
+        cantidad_cuotas: 4,
+        fecha_compra: '2026-01-15',
+        moneda_origen: 'ARS',
+        tipo_cambio_usado: null,
+        categoria_gasto_id: 1,
+        importancia_gasto_id: 1,
+        tipo_pago_id: 2,
+        tarjeta_id: null,
+        tarjeta: null,
+        usuario_id: 1
+      };
+
+      await strategy.generateHistoricalInstallments(compra, 2, mockTransaction);
+
+      expect(mockGastoCreate).toHaveBeenCalledTimes(2);
+      expect(mockGastoCreate.mock.calls[0][1]).toEqual({ transaction: mockTransaction });
+      expect(mockGastoCreate.mock.calls[1][1]).toEqual({ transaction: mockTransaction });
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Permite crear compras con cuotas ya pagadas (`cuotas_pagadas`), generando los Gasto históricos con fechas correctas según tipo de pago (tarjeta crédito vs otros)
- Corrige compras de 1 cuota con tarjeta de crédito: el gasto ahora se genera en la fecha de vencimiento (vía scheduler) en vez de inmediatamente con fecha de hoy
- La strategy de installments ahora usa `CreditCardDateService` para calcular la fecha del gasto en vez de usar siempre `today`

## Changes
- **validation.middleware.js / compra.validation.js**: campo `cuotas_pagadas` (integer, min 0, default 0)
- **installmentStrategy.js**: nuevo método `generateHistoricalInstallments()` + fix de fecha en `generate()` para tarjeta crédito
- **compra.controller.js**: lógica condicional en `create()` para cuotas pagadas, validación cruzada, defer de gasto para tarjeta crédito 1 cuota
- **swagger.yaml**: documentación del campo y response schema del POST
- **compra.cuotasPagadas.test.js**: 11 tests (validación, fechas mensuales, fechas tarjeta crédito, day clamping, future date clamping, transacciones)

## Test plan
- [x] `npm test` — 398 tests pass
- [ ] POST `/api/compras` con `cuotas_pagadas: 0` → comportamiento existente sin cambios
- [ ] POST `/api/compras` con `cuotas_pagadas: 3, cantidad_cuotas: 12, tarjeta_id: X` → 3 gastos con fechas de vencimiento
- [ ] POST `/api/compras` con `cuotas_pagadas: 3, cantidad_cuotas: 6` (sin tarjeta) → 3 gastos con fechas mensuales
- [ ] POST `/api/compras` con `cuotas_pagadas: 6, cantidad_cuotas: 6` → compra completamente pagada
- [ ] POST `/api/compras` con `cuotas_pagadas: 7, cantidad_cuotas: 6` → error de validación
- [ ] POST `/api/compras` con 1 cuota + tarjeta crédito → no genera gasto inmediato, queda pendiente para scheduler

🤖 Generated with [Claude Code](https://claude.com/claude-code)