### PR TITLE
fix: preserve real due dates for historical installments

### DIFF
--- a/src/strategies/expenseGeneration/installmentStrategy.js
+++ b/src/strategies/expenseGeneration/installmentStrategy.js
@@ -322,7 +322,6 @@ export class InstallmentExpenseStrategy extends BaseExpenseGenerationStrategy {
 
     const gastos = [];
     let lastDate = null;
-    const today = moment().tz('America/Argentina/Buenos_Aires');
 
     for (let i = 0; i < cuotasPagadas; i++) {
       let fechaMoment;
@@ -333,11 +332,6 @@ export class InstallmentExpenseStrategy extends BaseExpenseGenerationStrategy {
         const fechaCompra = moment(compra.fecha_compra);
         fechaMoment = moment(compra.fecha_compra).add(i, 'months');
         fechaMoment.date(Math.min(fechaCompra.date(), fechaMoment.daysInMonth()));
-      }
-
-      // Cuotas "pagadas" no pueden tener fecha futura
-      if (fechaMoment.isAfter(today, 'day')) {
-        fechaMoment = today.clone();
       }
 
       const fecha = fechaMoment.format('YYYY-MM-DD');

--- a/tests/unit/controllers/compra.cuotasPagadas.test.js
+++ b/tests/unit/controllers/compra.cuotasPagadas.test.js
@@ -321,7 +321,7 @@ describe('CompraController - cuotas_pagadas', () => {
       expect(call.monto_ars).toBe(500); // Full amount for single cuota
     });
 
-    it('should clamp future dates to today', async () => {
+    it('should preserve real dates even if they are in the future', async () => {
       const compra = {
         id: 6,
         descripcion: 'Compra reciente',
@@ -340,16 +340,13 @@ describe('CompraController - cuotas_pagadas', () => {
         usuario_id: 1
       };
 
-      // 3 cuotas: Feb 15 (past), Mar 15 (past), Apr 15 (future → clamped)
+      // 3 cuotas: Feb 15, Mar 15, Apr 15 — all keep their real dates
       const result = await strategy.generateHistoricalInstallments(compra, 3, mockTransaction);
 
       const calls = mockGastoCreate.mock.calls;
       expect(calls[0][0].fecha).toBe('2026-02-15');
       expect(calls[1][0].fecha).toBe('2026-03-15');
-      // Apr 15 is future, should be clamped to today
-      const moment = (await import('moment-timezone')).default;
-      const today = moment().tz('America/Argentina/Buenos_Aires').format('YYYY-MM-DD');
-      expect(calls[2][0].fecha).toBe(today);
+      expect(calls[2][0].fecha).toBe('2026-04-15');
     });
 
     it('should pass transaction to all Gasto.create calls', async () => {


### PR DESCRIPTION
## Summary
- Removed the future-date clamp in `generateHistoricalInstallments` that was forcing all cuotas_pagadas with future due dates to today's date
- Historical installments now always use their real credit card due date (calculated by `CreditCardDateService`)
- Updated test to verify dates are preserved instead of clamped

## Problem
When creating a compra with `cuotas_pagadas`, installments whose due date was in the future were all clamped to today. For example, a purchase from Dec 2025 with 4 paid installments would show all 4 gastos with today's date instead of Jan, Feb, Mar, Apr.

## Test plan
- [x] All 398 tests passing
- [ ] Create a compra with cuotas_pagadas on a credit card and verify each gasto has its correct historical due date

🤖 Generated with [Claude Code](https://claude.com/claude-code)