### PR TITLE
feat: add balance evolution API endpoint

### DIFF
--- a/migrations/023_add_balance_inicial_to_preferencias.sql
+++ b/migrations/023_add_balance_inicial_to_preferencias.sql
@@ -1,0 +1,7 @@
+-- Agregar campo balance_inicial a preferencias_usuario
+-- Permite al usuario definir su balance inicial antes de empezar a usar la app
+
+ALTER TABLE finanzas.preferencias_usuario
+ADD COLUMN IF NOT EXISTS balance_inicial DECIMAL(15,2) NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN finanzas.preferencias_usuario.balance_inicial IS 'Balance inicial del usuario antes de empezar a usar la app (en ARS)';

--- a/src/controllers/api/balance.controller.js
+++ b/src/controllers/api/balance.controller.js
@@ -1,0 +1,25 @@
+import logger from '../../utils/logger.js';
+import { sendError, sendSuccess } from '../../utils/responseHelper.js';
+import balanceService from '../../services/balance.service.js';
+
+/**
+ * Obtiene la evolución mensual del balance del usuario
+ * GET /api/balance/evolucion?desde=2025-01&hasta=2026-04
+ */
+export async function getEvolucionBalance(req, res) {
+  try {
+    const usuarioId = req.user.id;
+    const { desde, hasta } = req.query;
+
+    const evolucion = await balanceService.getEvolucionMensual(usuarioId, desde, hasta);
+
+    return sendSuccess(res, evolucion);
+  } catch (error) {
+    logger.error('Error al obtener evolución del balance:', { error });
+    return sendError(res, 500, 'Error al obtener evolución del balance', error.message);
+  }
+}
+
+export default {
+  getEvolucionBalance
+};

--- a/src/controllers/api/preferenciasUsuario.controller.js
+++ b/src/controllers/api/preferenciasUsuario.controller.js
@@ -24,11 +24,12 @@ export async function getPreferencias(req, res) {
 export async function updatePreferencias(req, res) {
   try {
     const usuarioId = req.user.id;
-    const { modulos_activos, tema } = req.body;
+    const { modulos_activos, tema, balance_inicial } = req.body;
 
     const preferencias = await preferenciasService.updatePreferencias(usuarioId, {
       modulos_activos,
-      tema
+      tema,
+      balance_inicial
     });
 
     logger.info('Preferencias actualizadas:', { usuarioId });

--- a/src/middlewares/validation.middleware.js
+++ b/src/middlewares/validation.middleware.js
@@ -796,3 +796,22 @@ const cuentaBancariaFiltersSchema = Joi.object({
 export const validateCreateCuentaBancaria = createValidationMiddleware(cuentaBancariaSchema, 'body');
 export const validateUpdateCuentaBancaria = createValidationMiddleware(cuentaBancariaSchema, 'body');
 export const validateCuentaBancariaFilters = createValidationMiddleware(cuentaBancariaFiltersSchema, 'query');
+
+// ==========================================
+// 📊 Balance - Evolución mensual
+// ==========================================
+
+const balanceEvolucionFiltersSchema = Joi.object({
+  desde: Joi.string().pattern(/^\d{4}-\d{2}$/).required()
+    .messages({
+      'string.pattern.base': 'El formato de "desde" debe ser YYYY-MM',
+      'any.required': 'El parámetro "desde" es requerido'
+    }),
+  hasta: Joi.string().pattern(/^\d{4}-\d{2}$/).required()
+    .messages({
+      'string.pattern.base': 'El formato de "hasta" debe ser YYYY-MM',
+      'any.required': 'El parámetro "hasta" es requerido'
+    })
+}).unknown(false);
+
+export const validateBalanceEvolucionFilters = createValidationMiddleware(balanceEvolucionFiltersSchema, 'query');

--- a/src/models/PreferenciasUsuario.model.js
+++ b/src/models/PreferenciasUsuario.model.js
@@ -65,6 +65,15 @@ export function definePreferenciasUsuario(sequelize) {
       allowNull: false,
       defaultValue: [],
       comment: 'IDs de fuentes de ingreso del sistema que el usuario quiere ocultar'
+    },
+    balance_inicial: {
+      type: DataTypes.DECIMAL(15, 2),
+      allowNull: false,
+      defaultValue: 0,
+      comment: 'Balance inicial del usuario antes de empezar a usar la app (en ARS)',
+      validate: {
+        min: 0
+      }
     }
   }, {
     tableName: 'preferencias_usuario',

--- a/src/routes/api/index.routes.js
+++ b/src/routes/api/index.routes.js
@@ -147,11 +147,13 @@ import {
   validateIngresoRecurrenteFilters,
   validateCreateCuentaBancaria,
   validateUpdateCuentaBancaria,
-  validateCuentaBancariaFilters
+  validateCuentaBancariaFilters,
+  validateBalanceEvolucionFilters
 } from '../../middlewares/validation.middleware.js';
 
 import { obtenerProyeccion } from '../../controllers/api/proyeccion.controller.js';
 import { obtenerSaludFinanciera } from '../../controllers/api/saludFinanciera.controller.js';
+import { getEvolucionBalance } from '../../controllers/api/balance.controller.js';
 import {
   getPreferencias,
   updatePreferencias,
@@ -276,6 +278,9 @@ router.get('/proyeccion', authenticateToken, validateProyeccionFilters, obtenerP
 
 // 💚 Rutas para Salud Financiera - Requieren autenticación
 router.get('/salud-financiera', authenticateToken, validateSaludFinancieraFilters, obtenerSaludFinanciera);
+
+// 📊 Rutas para Balance - Requieren autenticación
+router.get('/balance/evolucion', authenticateToken, validateBalanceEvolucionFilters, getEvolucionBalance);
 
 // ⚙️ Rutas para Preferencias de Usuario - Requieren autenticación
 router.get('/preferencias', authenticateToken, getPreferencias);

--- a/src/services/balance.service.js
+++ b/src/services/balance.service.js
@@ -1,0 +1,250 @@
+import { IngresoRecurrente } from '../models/index.js';
+import { sequelize } from '../models/index.js';
+import { QueryTypes } from 'sequelize';
+import { getOrCreatePreferencias } from './preferenciasUsuario.service.js';
+
+/**
+ * Obtiene la evolución mensual del balance de un usuario
+ * @param {number} usuarioId - ID del usuario
+ * @param {string} desde - Mes inicio (YYYY-MM)
+ * @param {string} hasta - Mes fin (YYYY-MM)
+ * @returns {Promise<Object>} Evolución mensual con balance acumulado
+ */
+export async function getEvolucionMensual(usuarioId, desde, hasta) {
+  const preferencias = await getOrCreatePreferencias(usuarioId);
+  const balanceInicial = parseFloat(preferencias.balance_inicial) || 0;
+
+  // Construir rango de fechas
+  const fechaDesde = `${desde}-01`;
+  const fechaHasta = getLastDayOfMonth(hasta);
+
+  // Query 0: Calcular saldo acumulado PREVIO al rango solicitado
+  // Esto asegura que el acumulado refleje toda la historia, no solo el rango
+  const [saldoPrevio] = await sequelize.query(`
+    SELECT
+      COALESCE((SELECT SUM(monto_ars) FROM finanzas.ingresos_unico WHERE usuario_id = :usuarioId AND fecha < :fechaDesde), 0)
+      - COALESCE((SELECT SUM(monto_ars) FROM finanzas.gastos WHERE usuario_id = :usuarioId AND fecha < :fechaDesde), 0)
+      AS saldo_previo_ars,
+      COALESCE((SELECT SUM(monto_usd) FROM finanzas.ingresos_unico WHERE usuario_id = :usuarioId AND fecha < :fechaDesde), 0)
+      - COALESCE((SELECT SUM(monto_usd) FROM finanzas.gastos WHERE usuario_id = :usuarioId AND fecha < :fechaDesde), 0)
+      AS saldo_previo_usd
+  `, {
+    replacements: { usuarioId, fechaDesde },
+    type: QueryTypes.SELECT
+  });
+
+  // Ingresos recurrentes previos al rango también contribuyen al saldo previo
+  const ingresosRecurrentesPrevios = await calcularIngresosRecurrentesPrevios(
+    usuarioId, fechaDesde
+  );
+
+  const saldoPrevioArs = parseFloat(saldoPrevio?.saldo_previo_ars || 0) + ingresosRecurrentesPrevios.ars;
+  const saldoPrevioUsd = parseFloat(saldoPrevio?.saldo_previo_usd || 0) + ingresosRecurrentesPrevios.usd;
+
+  // Query 1: Gastos agrupados por mes
+  const gastosPorMes = await sequelize.query(`
+    SELECT
+      TO_CHAR(fecha, 'YYYY-MM') as mes,
+      COALESCE(SUM(monto_ars), 0) as total_ars,
+      COALESCE(SUM(monto_usd), 0) as total_usd
+    FROM finanzas.gastos
+    WHERE usuario_id = :usuarioId
+      AND fecha >= :fechaDesde
+      AND fecha <= :fechaHasta
+    GROUP BY TO_CHAR(fecha, 'YYYY-MM')
+    ORDER BY mes
+  `, {
+    replacements: { usuarioId, fechaDesde, fechaHasta },
+    type: QueryTypes.SELECT
+  });
+
+  // Query 2: Ingresos únicos agrupados por mes
+  const ingresosUnicosPorMes = await sequelize.query(`
+    SELECT
+      TO_CHAR(fecha, 'YYYY-MM') as mes,
+      COALESCE(SUM(monto_ars), 0) as total_ars,
+      COALESCE(SUM(monto_usd), 0) as total_usd
+    FROM finanzas.ingresos_unico
+    WHERE usuario_id = :usuarioId
+      AND fecha >= :fechaDesde
+      AND fecha <= :fechaHasta
+    GROUP BY TO_CHAR(fecha, 'YYYY-MM')
+    ORDER BY mes
+  `, {
+    replacements: { usuarioId, fechaDesde, fechaHasta },
+    type: QueryTypes.SELECT
+  });
+
+  // Query 3: Ingresos recurrentes activos
+  const ingresosRecurrentes = await IngresoRecurrente.findAll({
+    where: {
+      usuario_id: usuarioId,
+      activo: true
+    },
+    raw: true
+  });
+
+  // Generar todos los meses del rango
+  const meses = generarMeses(desde, hasta);
+
+  // Crear mapas para lookup rápido
+  const gastosMap = new Map(gastosPorMes.map(g => [g.mes, g]));
+  const ingresosUnicosMap = new Map(ingresosUnicosPorMes.map(i => [i.mes, i]));
+
+  // Calcular evolución - arrancar desde balance_inicial + todo lo previo al rango
+  let acumuladoArs = balanceInicial + saldoPrevioArs;
+  let acumuladoUsd = saldoPrevioUsd;
+
+  const evolucion = meses.map(mes => {
+    const gastos = gastosMap.get(mes) || { total_ars: 0, total_usd: 0 };
+    const ingresosU = ingresosUnicosMap.get(mes) || { total_ars: 0, total_usd: 0 };
+
+    // Calcular ingresos recurrentes para este mes
+    const inicioMesStr = `${mes}-01`;
+    const finMesStr = getLastDayOfMonth(mes);
+
+    let ingresosRecArs = 0;
+    let ingresosRecUsd = 0;
+
+    ingresosRecurrentes.forEach(rec => {
+      // Verificar si el recurrente aplica en este mes
+      if (rec.fecha_inicio && rec.fecha_inicio > finMesStr) return;
+      if (rec.fecha_fin && rec.fecha_fin < inicioMesStr) return;
+
+      ingresosRecArs += parseFloat(rec.monto_ars || 0);
+      ingresosRecUsd += parseFloat(rec.monto_usd || 0);
+    });
+
+    const totalIngresosArs = parseFloat(ingresosU.total_ars) + ingresosRecArs;
+    const totalIngresosUsd = parseFloat(ingresosU.total_usd) + ingresosRecUsd;
+    const totalGastosArs = parseFloat(gastos.total_ars);
+    const totalGastosUsd = parseFloat(gastos.total_usd);
+
+    const saldoArs = totalIngresosArs - totalGastosArs;
+    const saldoUsd = totalIngresosUsd - totalGastosUsd;
+
+    acumuladoArs += saldoArs;
+    acumuladoUsd += saldoUsd;
+
+    return {
+      mes,
+      ingresos_ars: round2(totalIngresosArs),
+      gastos_ars: round2(totalGastosArs),
+      saldo_ars: round2(saldoArs),
+      acumulado_ars: round2(acumuladoArs),
+      ingresos_usd: round2(totalIngresosUsd),
+      gastos_usd: round2(totalGastosUsd),
+      saldo_usd: round2(saldoUsd),
+      acumulado_usd: round2(acumuladoUsd)
+    };
+  });
+
+  return {
+    balance_inicial: balanceInicial,
+    meses: evolucion,
+    balance_actual_ars: evolucion.length > 0 ? evolucion[evolucion.length - 1].acumulado_ars : balanceInicial,
+    balance_actual_usd: evolucion.length > 0 ? evolucion[evolucion.length - 1].acumulado_usd : 0
+  };
+}
+
+/**
+ * Calcula la suma de ingresos recurrentes para todos los meses previos al rango
+ * @param {number} usuarioId
+ * @param {string} fechaDesde - Fecha inicio del rango (YYYY-MM-DD)
+ * @returns {Promise<{ars: number, usd: number}>}
+ */
+async function calcularIngresosRecurrentesPrevios(usuarioId, fechaDesde) {
+  const recurrentes = await IngresoRecurrente.findAll({
+    where: { usuario_id: usuarioId, activo: true },
+    raw: true
+  });
+
+  if (recurrentes.length === 0) return { ars: 0, usd: 0 };
+
+  // Encontrar el mes más antiguo con datos del usuario
+  const [oldest] = await sequelize.query(`
+    SELECT MIN(fecha) as min_fecha FROM (
+      SELECT MIN(fecha) as fecha FROM finanzas.gastos WHERE usuario_id = :usuarioId
+      UNION ALL
+      SELECT MIN(fecha) as fecha FROM finanzas.ingresos_unico WHERE usuario_id = :usuarioId
+    ) t
+  `, { replacements: { usuarioId }, type: QueryTypes.SELECT });
+
+  if (!oldest?.min_fecha) return { ars: 0, usd: 0 };
+
+  const primerMes = oldest.min_fecha.slice(0, 7);
+  const mesAntesDel = fechaDesde.slice(0, 7);
+
+  // Si no hay meses previos, retornar 0
+  if (primerMes >= mesAntesDel) return { ars: 0, usd: 0 };
+
+  const mesesPrevios = generarMeses(primerMes, getPreviousMonth(mesAntesDel));
+  let totalArs = 0;
+  let totalUsd = 0;
+
+  mesesPrevios.forEach(mes => {
+    const inicioMesStr = `${mes}-01`;
+    const finMesStr = getLastDayOfMonth(mes);
+
+    recurrentes.forEach(rec => {
+      if (rec.fecha_inicio && rec.fecha_inicio > finMesStr) return;
+      if (rec.fecha_fin && rec.fecha_fin < inicioMesStr) return;
+      totalArs += parseFloat(rec.monto_ars || 0);
+      totalUsd += parseFloat(rec.monto_usd || 0);
+    });
+  });
+
+  return { ars: totalArs, usd: totalUsd };
+}
+
+/**
+ * Obtiene el mes anterior a un mes dado (YYYY-MM)
+ */
+function getPreviousMonth(mesStr) {
+  const [anio, mes] = mesStr.split('-').map(Number);
+  if (mes === 1) return `${anio - 1}-12`;
+  return `${anio}-${String(mes - 1).padStart(2, '0')}`;
+}
+
+/**
+ * Genera un array de strings YYYY-MM entre dos meses
+ */
+export function generarMeses(desde, hasta) {
+  const meses = [];
+  const [anioDesde, mesDesde] = desde.split('-').map(Number);
+  const [anioHasta, mesHasta] = hasta.split('-').map(Number);
+
+  let anio = anioDesde;
+  let mes = mesDesde;
+
+  while (anio < anioHasta || (anio === anioHasta && mes <= mesHasta)) {
+    meses.push(`${anio}-${String(mes).padStart(2, '0')}`);
+    mes++;
+    if (mes > 12) {
+      mes = 1;
+      anio++;
+    }
+  }
+
+  return meses;
+}
+
+/**
+ * Obtiene el último día de un mes dado en formato YYYY-MM
+ */
+export function getLastDayOfMonth(mesStr) {
+  const [anio, mes] = mesStr.split('-').map(Number);
+  const lastDay = new Date(anio, mes, 0).getDate();
+  return `${mesStr}-${String(lastDay).padStart(2, '0')}`;
+}
+
+/**
+ * Redondea a 2 decimales
+ */
+export function round2(num) {
+  return Math.round(num * 100) / 100;
+}
+
+export default {
+  getEvolucionMensual
+};

--- a/src/services/preferenciasUsuario.service.js
+++ b/src/services/preferenciasUsuario.service.js
@@ -56,6 +56,10 @@ export async function updatePreferencias(usuarioId, data) {
     updateData.tema = data.tema;
   }
 
+  if (data.balance_inicial !== undefined) {
+    updateData.balance_inicial = data.balance_inicial;
+  }
+
   await preferencias.update(updateData);
   return preferencias;
 }

--- a/tests/unit/services/balance.service.test.js
+++ b/tests/unit/services/balance.service.test.js
@@ -1,0 +1,322 @@
+import { jest } from '@jest/globals';
+import { QueryTypes } from 'sequelize';
+
+// Mock dependencies
+const mockSequelize = {
+  query: jest.fn()
+};
+
+const mockIngresoRecurrente = {
+  findAll: jest.fn()
+};
+
+const mockGetOrCreatePreferencias = jest.fn();
+
+jest.unstable_mockModule('../../../src/models/index.js', () => ({
+  sequelize: mockSequelize,
+  IngresoRecurrente: mockIngresoRecurrente,
+}));
+
+jest.unstable_mockModule('../../../src/services/preferenciasUsuario.service.js', () => ({
+  getOrCreatePreferencias: mockGetOrCreatePreferencias
+}));
+
+const {
+  getEvolucionMensual,
+  generarMeses,
+  getLastDayOfMonth,
+  round2
+} = await import('../../../src/services/balance.service.js');
+
+/**
+ * Helper to set up all mocks for getEvolucionMensual.
+ * The function now makes these calls in order:
+ *   1. getOrCreatePreferencias (set in beforeEach)
+ *   2. sequelize.query — saldo previo (Query 0)
+ *   3. sequelize.query — gastos por mes
+ *   4. sequelize.query — ingresos únicos por mes
+ *   5. IngresoRecurrente.findAll — recurrentes for main calculation
+ *   6. IngresoRecurrente.findAll — recurrentes for calcularIngresosRecurrentesPrevios
+ *   7. sequelize.query — oldest date (inside calcularIngresosRecurrentesPrevios)
+ */
+function setupMocks({
+  saldoPrevio = { saldo_previo_ars: '0', saldo_previo_usd: '0' },
+  gastosPorMes = [],
+  ingresosUnicosPorMes = [],
+  recurrentes = [],
+  oldestDate = null,
+} = {}) {
+  // Call order in getEvolucionMensual:
+  //   1. sequelize.query — saldo previo (Query 0)
+  //   2. calcularIngresosRecurrentesPrevios:
+  //      2a. IngresoRecurrente.findAll (1st findAll)
+  //      2b. sequelize.query — oldest date (ONLY if recurrentes.length > 0)
+  //   3. sequelize.query — gastos
+  //   4. sequelize.query — ingresos únicos
+  //   5. IngresoRecurrente.findAll — main recurrentes (2nd findAll)
+  const queryChain = mockSequelize.query
+    .mockResolvedValueOnce([saldoPrevio]);              // 1. saldo previo
+
+  if (recurrentes.length > 0) {
+    queryChain.mockResolvedValueOnce([{ min_fecha: oldestDate }]); // 2b. oldest date
+  }
+
+  queryChain
+    .mockResolvedValueOnce(gastosPorMes)                // 3. gastos
+    .mockResolvedValueOnce(ingresosUnicosPorMes);       // 4. ingresos únicos
+
+  mockIngresoRecurrente.findAll
+    .mockResolvedValueOnce(recurrentes)  // 2a. calcularIngresosRecurrentesPrevios
+    .mockResolvedValueOnce(recurrentes); // 5. main recurrentes
+}
+
+describe('Balance Service', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  // ==========================================
+  // Pure function tests
+  // ==========================================
+
+  describe('generarMeses', () => {
+    it('should generate months for a single month range', () => {
+      expect(generarMeses('2026-03', '2026-03')).toEqual(['2026-03']);
+    });
+
+    it('should generate months within same year', () => {
+      expect(generarMeses('2026-01', '2026-04')).toEqual([
+        '2026-01', '2026-02', '2026-03', '2026-04'
+      ]);
+    });
+
+    it('should generate months across year boundary', () => {
+      expect(generarMeses('2025-11', '2026-02')).toEqual([
+        '2025-11', '2025-12', '2026-01', '2026-02'
+      ]);
+    });
+
+    it('should handle full year range', () => {
+      const result = generarMeses('2026-01', '2026-12');
+      expect(result).toHaveLength(12);
+      expect(result[0]).toBe('2026-01');
+      expect(result[11]).toBe('2026-12');
+    });
+  });
+
+  describe('getLastDayOfMonth', () => {
+    it('should return 31 for January', () => {
+      expect(getLastDayOfMonth('2026-01')).toBe('2026-01-31');
+    });
+
+    it('should return 28 for February (non-leap year)', () => {
+      expect(getLastDayOfMonth('2025-02')).toBe('2025-02-28');
+    });
+
+    it('should return 29 for February (leap year)', () => {
+      expect(getLastDayOfMonth('2024-02')).toBe('2024-02-29');
+    });
+
+    it('should return 30 for April', () => {
+      expect(getLastDayOfMonth('2026-04')).toBe('2026-04-30');
+    });
+  });
+
+  describe('round2', () => {
+    it('should round to 2 decimal places', () => {
+      expect(round2(1.005)).toBe(1);
+      expect(round2(1.555)).toBe(1.56);
+      expect(round2(100.999)).toBe(101);
+    });
+
+    it('should handle integers', () => {
+      expect(round2(100)).toBe(100);
+    });
+
+    it('should handle zero', () => {
+      expect(round2(0)).toBe(0);
+    });
+
+    it('should handle negative numbers', () => {
+      expect(round2(-50.456)).toBe(-50.46);
+    });
+  });
+
+  // ==========================================
+  // getEvolucionMensual integration tests (with mocks)
+  // ==========================================
+
+  describe('getEvolucionMensual', () => {
+    const usuarioId = 1;
+
+    beforeEach(() => {
+      mockGetOrCreatePreferencias.mockResolvedValue({
+        balance_inicial: '500000'
+      });
+    });
+
+    it('should return correct structure with balance_inicial', async () => {
+      setupMocks();
+
+      const result = await getEvolucionMensual(usuarioId, '2026-04', '2026-04');
+
+      expect(result).toHaveProperty('balance_inicial', 500000);
+      expect(result).toHaveProperty('meses');
+      expect(result).toHaveProperty('balance_actual_ars');
+      expect(result).toHaveProperty('balance_actual_usd');
+    });
+
+    it('should calculate balance for a single month with gastos and ingresos', async () => {
+      setupMocks({
+        gastosPorMes: [{ mes: '2026-04', total_ars: '150000', total_usd: '100' }],
+        ingresosUnicosPorMes: [{ mes: '2026-04', total_ars: '200000', total_usd: '150' }],
+      });
+
+      const result = await getEvolucionMensual(usuarioId, '2026-04', '2026-04');
+
+      expect(result.meses).toHaveLength(1);
+      const mes = result.meses[0];
+      expect(mes.mes).toBe('2026-04');
+      expect(mes.ingresos_ars).toBe(200000);
+      expect(mes.gastos_ars).toBe(150000);
+      expect(mes.saldo_ars).toBe(50000);
+      expect(mes.acumulado_ars).toBe(550000); // 500000 + 50000
+    });
+
+    it('should accumulate balance across months', async () => {
+      setupMocks({
+        gastosPorMes: [
+          { mes: '2026-01', total_ars: '100000', total_usd: '0' },
+          { mes: '2026-02', total_ars: '80000', total_usd: '0' }
+        ],
+        ingresosUnicosPorMes: [
+          { mes: '2026-01', total_ars: '200000', total_usd: '0' },
+          { mes: '2026-02', total_ars: '60000', total_usd: '0' }
+        ],
+      });
+
+      const result = await getEvolucionMensual(usuarioId, '2026-01', '2026-02');
+
+      expect(result.meses).toHaveLength(2);
+      // Mes 1: 200k - 100k = +100k -> acumulado = 600k
+      expect(result.meses[0].saldo_ars).toBe(100000);
+      expect(result.meses[0].acumulado_ars).toBe(600000);
+      // Mes 2: 60k - 80k = -20k -> acumulado = 580k
+      expect(result.meses[1].saldo_ars).toBe(-20000);
+      expect(result.meses[1].acumulado_ars).toBe(580000);
+
+      expect(result.balance_actual_ars).toBe(580000);
+    });
+
+    it('should handle months with no data', async () => {
+      setupMocks();
+
+      const result = await getEvolucionMensual(usuarioId, '2026-01', '2026-03');
+
+      expect(result.meses).toHaveLength(3);
+      result.meses.forEach(mes => {
+        expect(mes.ingresos_ars).toBe(0);
+        expect(mes.gastos_ars).toBe(0);
+        expect(mes.saldo_ars).toBe(0);
+        expect(mes.acumulado_ars).toBe(500000);
+      });
+    });
+
+    it('should include recurring income in calculations', async () => {
+      const recurrentes = [
+        {
+          monto_ars: '100000',
+          monto_usd: '80',
+          activo: true,
+          fecha_inicio: null,
+          fecha_fin: null
+        }
+      ];
+      setupMocks({ recurrentes });
+
+      const result = await getEvolucionMensual(usuarioId, '2026-04', '2026-04');
+
+      expect(result.meses[0].ingresos_ars).toBe(100000);
+      expect(result.meses[0].acumulado_ars).toBe(600000);
+    });
+
+    it('should respect fecha_inicio and fecha_fin of recurring income', async () => {
+      const recurrentes = [
+        {
+          monto_ars: '100000',
+          monto_usd: '0',
+          activo: true,
+          fecha_inicio: '2026-02-01',
+          fecha_fin: '2026-02-28'
+        }
+      ];
+      setupMocks({ recurrentes });
+
+      const result = await getEvolucionMensual(usuarioId, '2026-01', '2026-03');
+
+      // Only February should have the recurring income
+      expect(result.meses[0].ingresos_ars).toBe(0);     // Jan
+      expect(result.meses[1].ingresos_ars).toBe(100000); // Feb
+      expect(result.meses[2].ingresos_ars).toBe(0);     // Mar
+    });
+
+    it('should handle balance_inicial = 0', async () => {
+      mockGetOrCreatePreferencias.mockResolvedValue({ balance_inicial: '0' });
+      setupMocks();
+
+      const result = await getEvolucionMensual(usuarioId, '2026-04', '2026-04');
+
+      expect(result.balance_inicial).toBe(0);
+      expect(result.meses[0].acumulado_ars).toBe(0);
+    });
+
+    it('should handle negative saldo (deficit)', async () => {
+      mockGetOrCreatePreferencias.mockResolvedValue({ balance_inicial: '100000' });
+      setupMocks({
+        gastosPorMes: [{ mes: '2026-04', total_ars: '200000', total_usd: '0' }],
+        ingresosUnicosPorMes: [{ mes: '2026-04', total_ars: '50000', total_usd: '0' }],
+      });
+
+      const result = await getEvolucionMensual(usuarioId, '2026-04', '2026-04');
+
+      expect(result.meses[0].saldo_ars).toBe(-150000);
+      expect(result.meses[0].acumulado_ars).toBe(-50000); // 100k - 150k
+    });
+
+    it('should include saldo previo from months before the range', async () => {
+      setupMocks({
+        saldoPrevio: { saldo_previo_ars: '200000', saldo_previo_usd: '100' },
+      });
+
+      const result = await getEvolucionMensual(usuarioId, '2026-04', '2026-04');
+
+      // acumulado = balance_inicial(500k) + saldo_previo(200k) + saldo_mes(0) = 700k
+      expect(result.meses[0].acumulado_ars).toBe(700000);
+      expect(result.meses[0].acumulado_usd).toBe(100);
+    });
+
+    it('should include recurring income from months before the range in saldo previo', async () => {
+      const recurrentes = [
+        {
+          monto_ars: '50000',
+          monto_usd: '0',
+          activo: true,
+          fecha_inicio: null,
+          fecha_fin: null
+        }
+      ];
+      // Oldest date is 3 months before the range start
+      setupMocks({
+        recurrentes,
+        oldestDate: '2026-01-15',
+      });
+
+      const result = await getEvolucionMensual(usuarioId, '2026-04', '2026-04');
+
+      // Recurring income of 50k for Jan, Feb, Mar (3 months before Apr) = 150k previo
+      // Plus 50k recurring in April itself
+      // acumulado = 500k + 150k (saldo previo recurrentes) + 50k (recurrente in Apr) = 700k
+      expect(result.meses[0].acumulado_ars).toBe(700000);
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `GET /balance/evolucion?desde=YYYY-MM&hasta=YYYY-MM` endpoint that calculates monthly balance evolution with accumulated totals in ARS and USD
- Add `balance_inicial` field to `PreferenciasUsuario` model (configurable starting balance before using the app)
- Balance calculation includes: balance_inicial + all prior-month saldo + recurring income history + current range income/gastos
- Add Joi validation, migration script, and 22 unit tests (all passing)

## Changes
- **New**: `src/services/balance.service.js` — core calculation with saldo previo, recurring income, and month-by-month accumulation
- **New**: `src/controllers/api/balance.controller.js` — endpoint controller
- **New**: `migrations/023_add_balance_inicial_to_preferencias.sql`
- **New**: `tests/unit/services/balance.service.test.js` — 22 tests covering pure functions and integration with mocks
- **Modified**: `PreferenciasUsuario.model.js` — added `balance_inicial` DECIMAL(15,2) field
- **Modified**: `preferenciasUsuario.service.js` / `controller.js` — accept and persist `balance_inicial`
- **Modified**: `validation.middleware.js` — added balance evolucion filters validation
- **Modified**: `index.routes.js` — registered new route

## Test plan
- [x] 22 unit tests pass (`node --experimental-vm-modules node_modules/.bin/jest`)
- [ ] Manual test: `GET /balance/evolucion?desde=2026-01&hasta=2026-04` returns correct accumulated balances
- [ ] Run migration on database
- [ ] Verify balance_inicial persists via PUT /preferencias

🤖 Generated with [Claude Code](https://claude.com/claude-code)