### PR TITLE
feat: balance acumulado evolution endpoint and dashboard personalization

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,10 @@ jobs:
     name: Run Tests
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+      pull-requests: write
+
     services:
       postgres:
         image: postgres:15

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -25,6 +25,10 @@ jobs:
             cd /opt/finanzas/api
             git pull origin master
 
+            # Run pending migrations
+            chmod +x ./scripts/migrate.sh
+            DB_NAME=finanzas_personal ./scripts/migrate.sh finanzas_postgres
+
             # Build image directly from Dockerfile
             docker build --no-cache -t finanzas-api:latest .
 

--- a/migrations/024_add_dashboard_sections_to_preferencias.sql
+++ b/migrations/024_add_dashboard_sections_to_preferencias.sql
@@ -1,0 +1,2 @@
+ALTER TABLE finanzas.preferencias_usuario
+ADD COLUMN IF NOT EXISTS dashboard_sections JSONB NOT NULL DEFAULT '["balance_acumulado","tasa_ahorro","evolucion_tabla","ingresos_vs_gastos","gastos_categoria","desglose_mes","gastos_recientes","proyeccion"]'::jsonb;

--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+# migrate.sh - Corre todas las migraciones pendientes en orden
+# Usa una tabla migrations_log para trackear cuáles ya corrieron
+# Uso: ./scripts/migrate.sh [postgres_container_name]
+# Default container name: finanzas_postgres
+
+set -e
+
+CONTAINER=${1:-finanzas_postgres}
+DB_USER=${DB_USER:-postgres}
+DB_NAME=${DB_NAME:-finanzas_personal}
+MIGRATIONS_DIR="$(cd "$(dirname "$0")/../migrations" && pwd)"
+
+echo "🔄 Corriendo migraciones en container '$CONTAINER' (DB: $DB_NAME)..."
+
+# Crear tabla de log si no existe
+docker exec "$CONTAINER" psql -U "$DB_USER" -d "$DB_NAME" -c "
+  CREATE TABLE IF NOT EXISTS finanzas.migrations_log (
+    id SERIAL PRIMARY KEY,
+    filename VARCHAR(255) NOT NULL UNIQUE,
+    applied_at TIMESTAMP DEFAULT NOW()
+  );
+"
+
+# Correr cada migración en orden si no fue aplicada aún
+for filepath in "$MIGRATIONS_DIR"/*.sql; do
+  filename=$(basename "$filepath")
+
+  # Verificar si ya fue aplicada
+  already_applied=$(docker exec "$CONTAINER" psql -U "$DB_USER" -d "$DB_NAME" -tAc \
+    "SELECT COUNT(*) FROM finanzas.migrations_log WHERE filename = '$filename';")
+
+  if [ "$already_applied" = "1" ]; then
+    echo "  ⏭️  $filename (ya aplicada)"
+  else
+    echo "  ▶️  $filename..."
+    docker exec -i "$CONTAINER" psql -U "$DB_USER" -d "$DB_NAME" -f - < "$filepath"
+    docker exec "$CONTAINER" psql -U "$DB_USER" -d "$DB_NAME" -c \
+      "INSERT INTO finanzas.migrations_log (filename) VALUES ('$filename');"
+    echo "  ✅ $filename aplicada"
+  fi
+done
+
+echo "✅ Migraciones completadas."

--- a/src/controllers/api/preferenciasUsuario.controller.js
+++ b/src/controllers/api/preferenciasUsuario.controller.js
@@ -24,12 +24,13 @@ export async function getPreferencias(req, res) {
 export async function updatePreferencias(req, res) {
   try {
     const usuarioId = req.user.id;
-    const { modulos_activos, tema, balance_inicial } = req.body;
+    const { modulos_activos, tema, balance_inicial, dashboard_sections } = req.body;
 
     const preferencias = await preferenciasService.updatePreferencias(usuarioId, {
       modulos_activos,
       tema,
-      balance_inicial
+      balance_inicial,
+      dashboard_sections
     });
 
     logger.info('Preferencias actualizadas:', { usuarioId });

--- a/src/models/PreferenciasUsuario.model.js
+++ b/src/models/PreferenciasUsuario.model.js
@@ -24,6 +24,21 @@ export const MODULOS_DISPONIBLES = {
 // Modulos habilitados por defecto (solo los opcionales que queremos activos inicialmente)
 export const MODULOS_DEFAULT = ['gastos_unicos', 'ingresos_unicos'];
 
+// Secciones del dashboard disponibles
+export const DASHBOARD_SECTIONS_DISPONIBLES = [
+  'balance_acumulado',
+  'tasa_ahorro',
+  'evolucion_tabla',
+  'ingresos_vs_gastos',
+  'gastos_categoria',
+  'desglose_mes',
+  'gastos_recientes',
+  'proyeccion',
+];
+
+// Todas las secciones activas por defecto
+export const DASHBOARD_SECTIONS_DEFAULT = [...DASHBOARD_SECTIONS_DISPONIBLES];
+
 export function definePreferenciasUsuario(sequelize) {
   return sequelize.define('PreferenciasUsuario', {
     id: {
@@ -74,6 +89,12 @@ export function definePreferenciasUsuario(sequelize) {
       validate: {
         min: 0
       }
+    },
+    dashboard_sections: {
+      type: DataTypes.JSONB,
+      allowNull: false,
+      defaultValue: DASHBOARD_SECTIONS_DEFAULT,
+      comment: 'Secciones del dashboard habilitadas por el usuario'
     }
   }, {
     tableName: 'preferencias_usuario',

--- a/src/services/preferenciasUsuario.service.js
+++ b/src/services/preferenciasUsuario.service.js
@@ -1,5 +1,5 @@
 import { PreferenciasUsuario } from '../models/index.js';
-import { MODULOS_DISPONIBLES, MODULOS_DEFAULT } from '../models/PreferenciasUsuario.model.js';
+import { MODULOS_DISPONIBLES, MODULOS_DEFAULT, DASHBOARD_SECTIONS_DISPONIBLES, DASHBOARD_SECTIONS_DEFAULT } from '../models/PreferenciasUsuario.model.js';
 
 /**
  * Obtiene las preferencias de un usuario, creándolas si no existen
@@ -15,7 +15,8 @@ export async function getOrCreatePreferencias(usuarioId) {
     preferencias = await PreferenciasUsuario.create({
       usuario_id: usuarioId,
       modulos_activos: MODULOS_DEFAULT,
-      tema: 'system'
+      tema: 'system',
+      dashboard_sections: DASHBOARD_SECTIONS_DEFAULT
     });
   }
 
@@ -58,6 +59,13 @@ export async function updatePreferencias(usuarioId, data) {
 
   if (data.balance_inicial !== undefined) {
     updateData.balance_inicial = data.balance_inicial;
+  }
+
+  if (data.dashboard_sections !== undefined) {
+    const seccionesValidas = data.dashboard_sections.filter(
+      s => DASHBOARD_SECTIONS_DISPONIBLES.includes(s)
+    );
+    updateData.dashboard_sections = seccionesValidas;
   }
 
   await preferencias.update(updateData);


### PR DESCRIPTION
## Summary

- **Balance evolution endpoint** (`GET /api/balance/evolucion?desde=&hasta=`): calculates accumulated balance per month including balance inicial, saldo previo (all history before range), gastos, ingresos únicos and recurring income
- **balance_inicial field** added to `preferencias_usuario` — lets users set their starting balance before using the app
- **dashboard_sections field** added to `preferencias_usuario` — JSONB array of visible dashboard sections for personalization
- **Automatic migrations on deploy**: `deploy.yml` now runs `scripts/migrate.sh` before rebuilding, so migrations apply automatically on every deploy to Hetzner
- **Unit tests**: 22 tests covering `getEvolucionMensual`, `generarMeses`, `getLastDayOfMonth`, `round2`, saldo previo accumulation, recurring income handling

## Key technical decisions

- Saldo previo is computed via a dedicated "Query 0" that sums all gastos/ingresos before the requested range, plus recurring income for those months — ensuring the accumulated balance reflects full history even when viewing a short date window
- Sequelize DECIMAL fields return strings; all monetary values use `parseFloat()` before arithmetic

## Migrations

- `023_add_balance_inicial_to_preferencias.sql`
- `024_add_dashboard_sections_to_preferencias.sql`

## Test plan

- [x] Unit tests: 22/22 passing (`npm run test`)
- [ ] Run E2E tests against staging after merge
- [ ] Verify migrations apply cleanly on Hetzner via deploy workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)