### PR TITLE
fix: correct trimestral/semestral/anual recurring expense frequency logic

### DIFF
--- a/docs/api/swagger.yaml
+++ b/docs/api/swagger.yaml
@@ -81,6 +81,28 @@ components:
           format: date-time
           description: Timestamp del error
 
+    PreferenciasUsuario:
+      type: object
+      properties:
+        balance_inicial_ars:
+          type: number
+          description: Balance inicial en pesos argentinos
+          example: 50000
+        balance_inicial_usd:
+          type: number
+          description: Balance inicial en dólares
+          example: 200
+        dashboard_sections:
+          type: object
+          description: Configuración de visibilidad de secciones del dashboard
+          additionalProperties:
+            type: boolean
+          example:
+            show_balance_acumulado: true
+            show_gastos_categoria: true
+            show_ingresos_vs_gastos: true
+            show_proyeccion: false
+
     ValidationError:
       type: object
       properties:
@@ -4932,6 +4954,184 @@ paths:
                     - "Considerá reducir gastos prescindibles"
         '400':
           description: Parámetros de validación inválidos
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /balance/evolucion:
+    get:
+      tags:
+        - Balance
+      summary: Evolución mensual del balance acumulado
+      description: |
+        Retorna el balance acumulado mes a mes considerando ingresos y gastos
+        en un rango de fechas. El balance inicial (configurable por el usuario)
+        se suma al primer mes para derivar el acumulado.
+      security:
+        - bearerAuth: []
+      parameters:
+        - in: query
+          name: fecha_inicio
+          required: true
+          schema:
+            type: string
+            format: date
+            example: '2026-01-01'
+          description: Fecha de inicio del rango (primer día del mes)
+        - in: query
+          name: fecha_fin
+          required: true
+          schema:
+            type: string
+            format: date
+            example: '2026-12-31'
+          description: Fecha de fin del rango (último día del mes)
+      responses:
+        '200':
+          description: Evolución mensual del balance
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  evolucion:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        mes:
+                          type: string
+                          description: Mes en formato YYYY-MM
+                          example: '2026-01'
+                        ingresos_ars:
+                          type: number
+                          example: 150000
+                        gastos_ars:
+                          type: number
+                          example: 120000
+                        balance_mes_ars:
+                          type: number
+                          description: Ingresos - Gastos del mes
+                          example: 30000
+                        balance_acumulado_ars:
+                          type: number
+                          description: Balance acumulado incluyendo balance inicial
+                          example: 80000
+                        ingresos_usd:
+                          type: number
+                          example: 0
+                        gastos_usd:
+                          type: number
+                          example: 100
+                        balance_mes_usd:
+                          type: number
+                          example: -100
+                        balance_acumulado_usd:
+                          type: number
+                          example: -100
+              example:
+                evolucion:
+                  - mes: '2026-01'
+                    ingresos_ars: 150000
+                    gastos_ars: 120000
+                    balance_mes_ars: 30000
+                    balance_acumulado_ars: 80000
+                    ingresos_usd: 0
+                    gastos_usd: 100
+                    balance_mes_usd: -100
+                    balance_acumulado_usd: -100
+        '400':
+          description: Parámetros de fecha inválidos
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ValidationError'
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+  /preferencias:
+    get:
+      tags:
+        - Preferencias
+      summary: Obtener preferencias del usuario
+      description: Retorna las preferencias del usuario autenticado, incluyendo balance inicial y configuración del dashboard.
+      security:
+        - bearerAuth: []
+      responses:
+        '200':
+          description: Preferencias del usuario
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PreferenciasUsuario'
+              example:
+                balance_inicial_ars: 50000
+                balance_inicial_usd: 200
+                dashboard_sections:
+                  show_balance_acumulado: true
+                  show_gastos_categoria: true
+                  show_ingresos_vs_gastos: true
+                  show_proyeccion: false
+        '401':
+          $ref: '#/components/responses/Unauthorized'
+        '500':
+          $ref: '#/components/responses/InternalError'
+
+    put:
+      tags:
+        - Preferencias
+      summary: Actualizar preferencias del usuario
+      description: |
+        Actualiza las preferencias del usuario. Solo los campos enviados
+        son actualizados (merge parcial). Los campos no enviados conservan
+        su valor anterior.
+      security:
+        - bearerAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                balance_inicial_ars:
+                  type: number
+                  description: Balance inicial en pesos argentinos
+                  example: 50000
+                balance_inicial_usd:
+                  type: number
+                  description: Balance inicial en dólares
+                  example: 200
+                dashboard_sections:
+                  type: object
+                  description: Mapa de secciones visibles en el dashboard
+                  additionalProperties:
+                    type: boolean
+                  example:
+                    show_balance_acumulado: true
+                    show_gastos_categoria: false
+            example:
+              balance_inicial_ars: 50000
+              balance_inicial_usd: 200
+              dashboard_sections:
+                show_balance_acumulado: true
+                show_gastos_categoria: true
+      responses:
+        '200':
+          description: Preferencias actualizadas
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/PreferenciasUsuario'
+        '400':
+          description: Datos inválidos
           content:
             application/json:
               schema:

--- a/src/services/debitoAutomatico.service.js
+++ b/src/services/debitoAutomatico.service.js
@@ -274,6 +274,20 @@ export class DebitoAutomaticoService extends BaseService {
         if (ultimaFecha.isSame(today, 'day')) {
           return { should: false, reason: 'Already generated today' };
         }
+      } else if (frecuenciaNombre === 'trimestral') {
+        const monthsSince = today.diff(ultimaFecha, 'months');
+        if (monthsSince < 3) {
+          return { should: false, reason: `Already generated ${monthsSince} months ago (quarterly needs 3)` };
+        }
+      } else if (frecuenciaNombre === 'semestral') {
+        const monthsSince = today.diff(ultimaFecha, 'months');
+        if (monthsSince < 6) {
+          return { should: false, reason: `Already generated ${monthsSince} months ago (semiannual needs 6)` };
+        }
+      } else if (frecuenciaNombre === 'anual') {
+        if (ultimaFecha.isSame(today, 'year')) {
+          return { should: false, reason: 'Already generated this year' };
+        }
       }
     }
 

--- a/src/services/gastoRecurrente.service.js
+++ b/src/services/gastoRecurrente.service.js
@@ -280,6 +280,26 @@ export class GastoRecurrenteService extends BaseService {
           result.reason = 'Already generated today';
           return result;
         }
+      } else if (frecuenciaNombre === 'trimestral') {
+        // For quarterly, check if already generated within the last 3 months
+        const monthsSince = today.diff(ultimaFecha, 'months');
+        if (monthsSince < 3) {
+          result.reason = `Already generated ${monthsSince} months ago (quarterly needs 3)`;
+          return result;
+        }
+      } else if (frecuenciaNombre === 'semestral') {
+        // For semiannual, check if already generated within the last 6 months
+        const monthsSince = today.diff(ultimaFecha, 'months');
+        if (monthsSince < 6) {
+          result.reason = `Already generated ${monthsSince} months ago (semiannual needs 6)`;
+          return result;
+        }
+      } else if (frecuenciaNombre === 'anual') {
+        // For annual, check if already generated this year
+        if (ultimaFecha.isSame(today, 'year')) {
+          result.reason = 'Already generated this year';
+          return result;
+        }
       }
     }
 
@@ -553,8 +573,10 @@ export class GastoRecurrenteService extends BaseService {
 
   /**
    * Check quarterly frequency (every 3 months)
+   * Uses ultima_fecha_generado to determine the next due month dynamically,
+   * so the schedule follows the actual start date rather than hardcoded months.
    */
-  checkQuarterlyFrequency(expense, today, diaActual, mesActual) {
+  checkQuarterlyFrequency(expense, today, diaActual, _mesActual) {
     const targetDay = expense.dia_de_pago;
     const adjustedDate = this.getValidMonthlyDate(today, targetDay);
     const adjustedDay = adjustedDate.date();
@@ -567,27 +589,39 @@ export class GastoRecurrenteService extends BaseService {
       };
     }
 
-    // Check if current month is a quarter month (1, 4, 7, 10)
-    const quarterMonths = [1, 4, 7, 10];
-    if (!quarterMonths.includes(mesActual)) {
+    // First generation ever
+    if (!expense.ultima_fecha_generado) {
       return {
-        matches: false,
-        reason: `Quarterly frequency - not a quarter month (${mesActual})`,
-        adjustedDate: null
+        matches: true,
+        reason: 'First quarterly generation',
+        adjustedDate: adjustedDate.format('YYYY-MM-DD')
+      };
+    }
+
+    const lastGeneration = moment(expense.ultima_fecha_generado);
+    const monthsSince = today.diff(lastGeneration, 'months');
+
+    if (monthsSince >= 3) {
+      return {
+        matches: true,
+        reason: `Quarterly frequency - ${monthsSince} months since last generation`,
+        adjustedDate: adjustedDate.format('YYYY-MM-DD')
       };
     }
 
     return {
-      matches: true,
-      reason: `Quarterly frequency - generating in quarter month ${mesActual}`,
-      adjustedDate: adjustedDate.format('YYYY-MM-DD')
+      matches: false,
+      reason: `Quarterly frequency - only ${monthsSince} months since last generation`,
+      adjustedDate: null
     };
   }
 
   /**
    * Check semiannual frequency (every 6 months)
+   * Uses ultima_fecha_generado to determine the next due month dynamically,
+   * so the schedule follows the actual start date rather than hardcoded months.
    */
-  checkSemiannualFrequency(expense, today, diaActual, mesActual) {
+  checkSemiannualFrequency(expense, today, diaActual, _mesActual) {
     const targetDay = expense.dia_de_pago;
     const adjustedDate = this.getValidMonthlyDate(today, targetDay);
     const adjustedDay = adjustedDate.date();
@@ -600,20 +634,30 @@ export class GastoRecurrenteService extends BaseService {
       };
     }
 
-    // Check if current month is a semiannual month (1, 7)
-    const semiannualMonths = [1, 7];
-    if (!semiannualMonths.includes(mesActual)) {
+    // First generation ever
+    if (!expense.ultima_fecha_generado) {
       return {
-        matches: false,
-        reason: `Semiannual frequency - not a semiannual month (${mesActual})`,
-        adjustedDate: null
+        matches: true,
+        reason: 'First semiannual generation',
+        adjustedDate: adjustedDate.format('YYYY-MM-DD')
+      };
+    }
+
+    const lastGeneration = moment(expense.ultima_fecha_generado);
+    const monthsSince = today.diff(lastGeneration, 'months');
+
+    if (monthsSince >= 6) {
+      return {
+        matches: true,
+        reason: `Semiannual frequency - ${monthsSince} months since last generation`,
+        adjustedDate: adjustedDate.format('YYYY-MM-DD')
       };
     }
 
     return {
-      matches: true,
-      reason: `Semiannual frequency - generating in month ${mesActual}`,
-      adjustedDate: adjustedDate.format('YYYY-MM-DD')
+      matches: false,
+      reason: `Semiannual frequency - only ${monthsSince} months since last generation`,
+      adjustedDate: null
     };
   }
 

--- a/src/services/proyeccion.service.js
+++ b/src/services/proyeccion.service.js
@@ -379,6 +379,7 @@ export class ProyeccionService {
     }
 
     case 'bimestral': {
+      // Every 2 months from fecha_inicio. Uses moment.diff to handle year boundaries correctly.
       if (!expense.fecha_inicio) return { generates: false, dates: [] };
       const fechaInicio = moment(expense.fecha_inicio);
       const monthsSinceStart = targetMonth.diff(fechaInicio, 'months');
@@ -390,6 +391,7 @@ export class ProyeccionService {
     }
 
     case 'trimestral': {
+      // Every 3 months from fecha_inicio. Uses moment.diff to handle year boundaries correctly.
       if (!expense.fecha_inicio) return { generates: false, dates: [] };
       const fechaInicio = moment(expense.fecha_inicio);
       const monthsSinceStart = targetMonth.diff(fechaInicio, 'months');
@@ -401,6 +403,7 @@ export class ProyeccionService {
     }
 
     case 'semestral': {
+      // Every 6 months from fecha_inicio. Uses moment.diff to handle year boundaries correctly.
       if (!expense.fecha_inicio) return { generates: false, dates: [] };
       const fechaInicio = moment(expense.fecha_inicio);
       const monthsSinceStart = targetMonth.diff(fechaInicio, 'months');

--- a/src/services/proyeccion.service.js
+++ b/src/services/proyeccion.service.js
@@ -379,16 +379,9 @@ export class ProyeccionService {
     }
 
     case 'bimestral': {
-      // Every 2 months - check if this month is in sequence
-      // Starting from month 1, generates on months 1, 3, 5, 7, 9, 11
-      // Starting from month 2, generates on months 2, 4, 6, 8, 10, 12
-      const monthNumber = targetMonth.month() + 1; // 1-12
-      const startMonth = expense.fecha_inicio ?
-        moment(expense.fecha_inicio).month() + 1 :
-        1;
-
-      // Check if months since start is divisible by 2
-      const monthsSinceStart = monthNumber - startMonth;
+      if (!expense.fecha_inicio) return { generates: false, dates: [] };
+      const fechaInicio = moment(expense.fecha_inicio);
+      const monthsSinceStart = targetMonth.diff(fechaInicio, 'months');
       if (monthsSinceStart >= 0 && monthsSinceStart % 2 === 0) {
         const validDate = this.getValidDayForMonth(targetMonth, targetDay);
         return { generates: true, dates: [validDate] };
@@ -397,11 +390,10 @@ export class ProyeccionService {
     }
 
     case 'trimestral': {
-      // Every 3 months - months 1, 4, 7, 10 or based on start month
-      const monthNumber = targetMonth.month() + 1;
-      const quarterMonths = [1, 4, 7, 10];
-
-      if (quarterMonths.includes(monthNumber)) {
+      if (!expense.fecha_inicio) return { generates: false, dates: [] };
+      const fechaInicio = moment(expense.fecha_inicio);
+      const monthsSinceStart = targetMonth.diff(fechaInicio, 'months');
+      if (monthsSinceStart >= 0 && monthsSinceStart % 3 === 0) {
         const validDate = this.getValidDayForMonth(targetMonth, targetDay);
         return { generates: true, dates: [validDate] };
       }
@@ -409,11 +401,10 @@ export class ProyeccionService {
     }
 
     case 'semestral': {
-      // Every 6 months - months 1, 7 or based on mes_de_pago
-      const monthNumber = targetMonth.month() + 1;
-      const semesterMonths = [1, 7];
-
-      if (semesterMonths.includes(monthNumber)) {
+      if (!expense.fecha_inicio) return { generates: false, dates: [] };
+      const fechaInicio = moment(expense.fecha_inicio);
+      const monthsSinceStart = targetMonth.diff(fechaInicio, 'months');
+      if (monthsSinceStart >= 0 && monthsSinceStart % 6 === 0) {
         const validDate = this.getValidDayForMonth(targetMonth, targetDay);
         return { generates: true, dates: [validDate] };
       }

--- a/tests/unit/services/debitoAutomatico.frequency.test.js
+++ b/tests/unit/services/debitoAutomatico.frequency.test.js
@@ -1,0 +1,187 @@
+import { jest } from '@jest/globals';
+import moment from 'moment-timezone';
+
+jest.unstable_mockModule('../../../src/models/index.js', () => ({
+  DebitoAutomatico: {},
+  CategoriaGasto: {},
+  ImportanciaGasto: {},
+  TipoPago: {},
+  Tarjeta: {},
+  FrecuenciaGasto: {},
+  Op: {},
+}));
+
+jest.unstable_mockModule('../../../src/services/exchangeRate.service.js', () => ({
+  default: { getLatestRate: jest.fn() },
+}));
+
+const { DebitoAutomaticoService } = await import('../../../src/services/debitoAutomatico.service.js');
+
+const service = new DebitoAutomaticoService();
+const TZ = 'America/Argentina/Buenos_Aires';
+
+function makeDebit({ frecuencia, dia_de_pago, mes_de_pago = null, ultima_fecha_generado = null, fecha_inicio = '2026-01-01', fecha_fin = null } = {}) {
+  return {
+    dia_de_pago,
+    mes_de_pago,
+    ultima_fecha_generado,
+    fecha_inicio,
+    fecha_fin,
+    activo: true,
+    frecuencia: { nombre_frecuencia: frecuencia },
+  };
+}
+
+describe('DebitoAutomaticoService - duplicate prevention for long-period frequencies', () => {
+
+  // ─── TRIMESTRAL ────────────────────────────────────────────────────────────
+
+  describe('trimestral', () => {
+    it('blocks generation if already generated 2 months ago', async () => {
+      const today = moment.tz('2026-05-15', TZ);
+      const debit = makeDebit({
+        frecuencia: 'trimestral',
+        dia_de_pago: 15,
+        fecha_inicio: '2026-01-15',
+        ultima_fecha_generado: '2026-03-15',
+      });
+      const result = await service.shouldGenerateExpense(debit, today);
+      expect(result.should).toBe(false);
+      expect(result.reason).toMatch(/2 months ago/);
+    });
+
+    it('allows generation after 3 months', async () => {
+      const today = moment.tz('2026-06-15', TZ);
+      const debit = makeDebit({
+        frecuencia: 'trimestral',
+        dia_de_pago: 15,
+        fecha_inicio: '2026-03-15',
+        ultima_fecha_generado: '2026-03-15',
+      });
+      const result = await service.shouldGenerateExpense(debit, today);
+      expect(result.should).toBe(true);
+    });
+
+    it('allows first generation (no ultima_fecha_generado)', async () => {
+      const today = moment.tz('2026-03-15', TZ);
+      const debit = makeDebit({
+        frecuencia: 'trimestral',
+        dia_de_pago: 15,
+        fecha_inicio: '2026-03-15',
+      });
+      const result = await service.shouldGenerateExpense(debit, today);
+      expect(result.should).toBe(true);
+    });
+  });
+
+  // ─── SEMESTRAL ─────────────────────────────────────────────────────────────
+
+  describe('semestral', () => {
+    it('blocks generation if already generated 5 months ago', async () => {
+      const today = moment.tz('2026-08-15', TZ);
+      const debit = makeDebit({
+        frecuencia: 'semestral',
+        dia_de_pago: 15,
+        fecha_inicio: '2026-03-15',
+        ultima_fecha_generado: '2026-03-15',
+      });
+      const result = await service.shouldGenerateExpense(debit, today);
+      expect(result.should).toBe(false);
+      expect(result.reason).toMatch(/5 months ago/);
+    });
+
+    it('allows generation after 6 months', async () => {
+      const today = moment.tz('2026-09-15', TZ);
+      const debit = makeDebit({
+        frecuencia: 'semestral',
+        dia_de_pago: 15,
+        fecha_inicio: '2026-03-15',
+        ultima_fecha_generado: '2026-03-15',
+      });
+      const result = await service.shouldGenerateExpense(debit, today);
+      expect(result.should).toBe(true);
+    });
+
+    it('allows first generation (no ultima_fecha_generado)', async () => {
+      const today = moment.tz('2026-03-15', TZ);
+      const debit = makeDebit({
+        frecuencia: 'semestral',
+        dia_de_pago: 15,
+        fecha_inicio: '2026-03-15',
+      });
+      const result = await service.shouldGenerateExpense(debit, today);
+      expect(result.should).toBe(true);
+    });
+  });
+
+  // ─── ANUAL ─────────────────────────────────────────────────────────────────
+
+  describe('anual', () => {
+    it('blocks generation if already generated this year', async () => {
+      const today = moment.tz('2026-04-20', TZ);
+      const debit = makeDebit({
+        frecuencia: 'anual',
+        dia_de_pago: 10,
+        mes_de_pago: 1,
+        fecha_inicio: '2026-01-10',
+        ultima_fecha_generado: '2026-01-10',
+      });
+      const result = await service.shouldGenerateExpense(debit, today);
+      expect(result.should).toBe(false);
+      expect(result.reason).toMatch(/Already generated this year/);
+    });
+
+    it('allows generation in a new year', async () => {
+      const today = moment.tz('2027-01-10', TZ);
+      const debit = makeDebit({
+        frecuencia: 'anual',
+        dia_de_pago: 10,
+        mes_de_pago: 1,
+        fecha_inicio: '2026-01-10',
+        ultima_fecha_generado: '2026-01-10',
+      });
+      const result = await service.shouldGenerateExpense(debit, today);
+      expect(result.should).toBe(true);
+    });
+
+    it('allows first generation (no ultima_fecha_generado)', async () => {
+      const today = moment.tz('2026-01-10', TZ);
+      const debit = makeDebit({
+        frecuencia: 'anual',
+        dia_de_pago: 10,
+        mes_de_pago: 1,
+        fecha_inicio: '2026-01-10',
+      });
+      const result = await service.shouldGenerateExpense(debit, today);
+      expect(result.should).toBe(true);
+    });
+  });
+
+  // ─── EXISTING FREQUENCIES UNAFFECTED ──────────────────────────────────────
+
+  describe('mensual - existing behavior unchanged', () => {
+    it('blocks if already generated this month', async () => {
+      const today = moment.tz('2026-04-20', TZ);
+      const debit = makeDebit({
+        frecuencia: 'mensual',
+        dia_de_pago: 15,
+        fecha_inicio: '2026-01-15',
+        ultima_fecha_generado: '2026-04-15',
+      });
+      const result = await service.shouldGenerateExpense(debit, today);
+      expect(result.should).toBe(false);
+    });
+
+    it('allows if last generated previous month', async () => {
+      const today = moment.tz('2026-04-15', TZ);
+      const debit = makeDebit({
+        frecuencia: 'mensual',
+        dia_de_pago: 15,
+        fecha_inicio: '2026-01-15',
+        ultima_fecha_generado: '2026-03-15',
+      });
+      const result = await service.shouldGenerateExpense(debit, today);
+      expect(result.should).toBe(true);
+    });
+  });
+});

--- a/tests/unit/services/gastoRecurrente.frequency.test.js
+++ b/tests/unit/services/gastoRecurrente.frequency.test.js
@@ -1,0 +1,226 @@
+import { jest } from '@jest/globals';
+import moment from 'moment-timezone';
+
+// Mock all model dependencies
+jest.unstable_mockModule('../../../src/models/index.js', () => ({
+  GastoRecurrente: {},
+  CategoriaGasto: {},
+  ImportanciaGasto: {},
+  TipoPago: {},
+  Tarjeta: {},
+  FrecuenciaGasto: {},
+}));
+
+jest.unstable_mockModule('../../../src/services/exchangeRate.service.js', () => ({
+  default: { getLatestRate: jest.fn() },
+}));
+
+const { GastoRecurrenteService } = await import('../../../src/services/gastoRecurrente.service.js');
+
+const service = new GastoRecurrenteService();
+const TZ = 'America/Argentina/Buenos_Aires';
+
+function makeExpense({ frecuencia, dia_de_pago, mes_de_pago = null, ultima_fecha_generado = null, fecha_inicio = null } = {}) {
+  return {
+    dia_de_pago,
+    mes_de_pago,
+    ultima_fecha_generado,
+    fecha_inicio,
+    frecuencia: { nombre_frecuencia: frecuencia },
+  };
+}
+
+describe('GastoRecurrenteService - frequency checks', () => {
+
+  // ─── TRIMESTRAL ────────────────────────────────────────────────────────────
+
+  describe('checkQuarterlyFrequency', () => {
+    it('generates on first time (no ultima_fecha_generado)', () => {
+      const today = moment.tz('2026-05-15', TZ);
+      const expense = makeExpense({ frecuencia: 'trimestral', dia_de_pago: 15 });
+      const result = service.checkQuarterlyFrequency(expense, today, 15, 5);
+      expect(result.matches).toBe(true);
+      expect(result.reason).toMatch(/First quarterly/);
+    });
+
+    it('does not generate if only 2 months since last generation', () => {
+      const today = moment.tz('2026-05-15', TZ);
+      const expense = makeExpense({ frecuencia: 'trimestral', dia_de_pago: 15, ultima_fecha_generado: '2026-03-15' });
+      const result = service.checkQuarterlyFrequency(expense, today, 15, 5);
+      expect(result.matches).toBe(false);
+      expect(result.reason).toMatch(/only 2 months/);
+    });
+
+    it('generates after 3 months', () => {
+      const today = moment.tz('2026-06-15', TZ);
+      const expense = makeExpense({ frecuencia: 'trimestral', dia_de_pago: 15, ultima_fecha_generado: '2026-03-15' });
+      const result = service.checkQuarterlyFrequency(expense, today, 15, 6);
+      expect(result.matches).toBe(true);
+    });
+
+    it('does not generate on wrong day', () => {
+      const today = moment.tz('2026-06-10', TZ);
+      const expense = makeExpense({ frecuencia: 'trimestral', dia_de_pago: 15, ultima_fecha_generado: '2026-03-15' });
+      const result = service.checkQuarterlyFrequency(expense, today, 10, 6);
+      expect(result.matches).toBe(false);
+      expect(result.reason).toMatch(/wrong day/);
+    });
+
+    it('respects any start month, not just hardcoded 1/4/7/10', () => {
+      // Created in Feb, first generation should be in Feb, next in May — not locked to Jan/Apr/Jul/Oct
+      const today = moment.tz('2026-02-15', TZ);
+      const expense = makeExpense({ frecuencia: 'trimestral', dia_de_pago: 15 }); // no ultima_fecha_generado
+      const result = service.checkQuarterlyFrequency(expense, today, 15, 2);
+      expect(result.matches).toBe(true); // Feb is valid because it's the first generation
+    });
+  });
+
+  // ─── SEMESTRAL ─────────────────────────────────────────────────────────────
+
+  describe('checkSemiannualFrequency', () => {
+    it('generates on first time (no ultima_fecha_generado)', () => {
+      const today = moment.tz('2026-03-15', TZ);
+      const expense = makeExpense({ frecuencia: 'semestral', dia_de_pago: 15 });
+      const result = service.checkSemiannualFrequency(expense, today, 15, 3);
+      expect(result.matches).toBe(true);
+      expect(result.reason).toMatch(/First semiannual/);
+    });
+
+    it('does not generate if only 5 months since last generation', () => {
+      const today = moment.tz('2026-08-15', TZ);
+      const expense = makeExpense({ frecuencia: 'semestral', dia_de_pago: 15, ultima_fecha_generado: '2026-03-15' });
+      const result = service.checkSemiannualFrequency(expense, today, 15, 8);
+      expect(result.matches).toBe(false);
+      expect(result.reason).toMatch(/only 5 months/);
+    });
+
+    it('generates after 6 months', () => {
+      const today = moment.tz('2026-09-15', TZ);
+      const expense = makeExpense({ frecuencia: 'semestral', dia_de_pago: 15, ultima_fecha_generado: '2026-03-15' });
+      const result = service.checkSemiannualFrequency(expense, today, 15, 9);
+      expect(result.matches).toBe(true);
+    });
+
+    it('respects any start month, not just hardcoded 1/7', () => {
+      // Created in March — should generate in March (first time), not forced to wait for January
+      const today = moment.tz('2026-03-15', TZ);
+      const expense = makeExpense({ frecuencia: 'semestral', dia_de_pago: 15 });
+      const result = service.checkSemiannualFrequency(expense, today, 15, 3);
+      expect(result.matches).toBe(true);
+    });
+
+    it('does not generate on wrong day', () => {
+      const today = moment.tz('2026-09-10', TZ);
+      const expense = makeExpense({ frecuencia: 'semestral', dia_de_pago: 15, ultima_fecha_generado: '2026-03-15' });
+      const result = service.checkSemiannualFrequency(expense, today, 10, 9);
+      expect(result.matches).toBe(false);
+    });
+  });
+
+  // ─── ANUAL ─────────────────────────────────────────────────────────────────
+
+  describe('checkAnnualFrequency', () => {
+    it('generates on correct month and day', () => {
+      const today = moment.tz('2026-04-15', TZ);
+      const expense = makeExpense({ frecuencia: 'anual', dia_de_pago: 15, mes_de_pago: 4 });
+      const result = service.checkAnnualFrequency(expense, today, 15, 4);
+      expect(result.matches).toBe(true);
+    });
+
+    it('does not generate on wrong month', () => {
+      const today = moment.tz('2026-05-15', TZ);
+      const expense = makeExpense({ frecuencia: 'anual', dia_de_pago: 15, mes_de_pago: 4 });
+      const result = service.checkAnnualFrequency(expense, today, 15, 5);
+      expect(result.matches).toBe(false);
+    });
+
+    it('requires mes_de_pago to be set', () => {
+      const today = moment.tz('2026-04-15', TZ);
+      const expense = makeExpense({ frecuencia: 'anual', dia_de_pago: 15, mes_de_pago: null });
+      const result = service.checkAnnualFrequency(expense, today, 15, 4);
+      expect(result.matches).toBe(false);
+      expect(result.reason).toMatch(/mes_de_pago/);
+    });
+  });
+
+  // ─── DUPLICATE PREVENTION in shouldGenerateExpense ─────────────────────────
+
+  describe('shouldGenerateExpense - duplicate prevention', () => {
+    it('trimestral: blocks if generated 2 months ago', async () => {
+      const today = moment.tz('2026-05-15', TZ);
+      const expense = makeExpense({
+        frecuencia: 'trimestral',
+        dia_de_pago: 15,
+        ultima_fecha_generado: '2026-03-15',
+        fecha_inicio: '2026-01-01',
+      });
+      const result = await service.shouldGenerateExpense(expense, today);
+      expect(result.canGenerate).toBe(false);
+      expect(result.reason).toMatch(/2 months ago/);
+    });
+
+    it('trimestral: allows if generated 3 months ago', async () => {
+      const today = moment.tz('2026-06-15', TZ);
+      const expense = makeExpense({
+        frecuencia: 'trimestral',
+        dia_de_pago: 15,
+        ultima_fecha_generado: '2026-03-15',
+        fecha_inicio: '2026-01-01',
+      });
+      const result = await service.shouldGenerateExpense(expense, today);
+      expect(result.canGenerate).toBe(true);
+    });
+
+    it('semestral: blocks if generated 5 months ago', async () => {
+      const today = moment.tz('2026-08-15', TZ);
+      const expense = makeExpense({
+        frecuencia: 'semestral',
+        dia_de_pago: 15,
+        ultima_fecha_generado: '2026-03-15',
+        fecha_inicio: '2026-01-01',
+      });
+      const result = await service.shouldGenerateExpense(expense, today);
+      expect(result.canGenerate).toBe(false);
+      expect(result.reason).toMatch(/5 months ago/);
+    });
+
+    it('semestral: allows if generated 6 months ago', async () => {
+      const today = moment.tz('2026-09-15', TZ);
+      const expense = makeExpense({
+        frecuencia: 'semestral',
+        dia_de_pago: 15,
+        ultima_fecha_generado: '2026-03-15',
+        fecha_inicio: '2026-01-01',
+      });
+      const result = await service.shouldGenerateExpense(expense, today);
+      expect(result.canGenerate).toBe(true);
+    });
+
+    it('anual: blocks if already generated this year', async () => {
+      const today = moment.tz('2026-04-20', TZ);
+      const expense = makeExpense({
+        frecuencia: 'anual',
+        dia_de_pago: 15,
+        mes_de_pago: 4,
+        ultima_fecha_generado: '2026-04-15',
+        fecha_inicio: '2025-01-01',
+      });
+      const result = await service.shouldGenerateExpense(expense, today);
+      expect(result.canGenerate).toBe(false);
+      expect(result.reason).toMatch(/Already generated this year/);
+    });
+
+    it('anual: allows if last generated previous year', async () => {
+      const today = moment.tz('2026-04-15', TZ);
+      const expense = makeExpense({
+        frecuencia: 'anual',
+        dia_de_pago: 15,
+        mes_de_pago: 4,
+        ultima_fecha_generado: '2025-04-15',
+        fecha_inicio: '2025-01-01',
+      });
+      const result = await service.shouldGenerateExpense(expense, today);
+      expect(result.canGenerate).toBe(true);
+    });
+  });
+});

--- a/tests/unit/services/proyeccion.willGenerateInMonth.test.js
+++ b/tests/unit/services/proyeccion.willGenerateInMonth.test.js
@@ -1,0 +1,152 @@
+import { jest } from '@jest/globals';
+import moment from 'moment-timezone';
+
+jest.unstable_mockModule('../../../src/models/index.js', () => ({
+  GastoRecurrente: {},
+  DebitoAutomatico: {},
+  Compra: {},
+  Gasto: {},
+  CategoriaGasto: {},
+  ImportanciaGasto: {},
+  TipoPago: {},
+  Tarjeta: {},
+  FrecuenciaGasto: {},
+}));
+
+const { ProyeccionService } = await import('../../../src/services/proyeccion.service.js');
+
+const TZ = 'America/Argentina/Buenos_Aires';
+
+function expense({ dia_de_pago, mes_de_pago = null, fecha_inicio }) {
+  return { dia_de_pago, mes_de_pago, fecha_inicio };
+}
+
+function month(str) {
+  return moment.tz(str, TZ).startOf('month');
+}
+
+describe('ProyeccionService.willGenerateInMonth', () => {
+
+  // ─── TRIMESTRAL ────────────────────────────────────────────────────────────
+
+  describe('trimestral', () => {
+    it('generates on the start month (monthsSince = 0)', () => {
+      const e = expense({ dia_de_pago: 15, fecha_inicio: '2026-03-01' });
+      expect(ProyeccionService.willGenerateInMonth(e, 'trimestral', month('2026-03-01')).generates).toBe(true);
+    });
+
+    it('generates 3 months after start', () => {
+      const e = expense({ dia_de_pago: 15, fecha_inicio: '2026-03-01' });
+      expect(ProyeccionService.willGenerateInMonth(e, 'trimestral', month('2026-06-01')).generates).toBe(true);
+    });
+
+    it('generates 6 months after start', () => {
+      const e = expense({ dia_de_pago: 15, fecha_inicio: '2026-03-01' });
+      expect(ProyeccionService.willGenerateInMonth(e, 'trimestral', month('2026-09-01')).generates).toBe(true);
+    });
+
+    it('does NOT generate 1 month after start', () => {
+      const e = expense({ dia_de_pago: 15, fecha_inicio: '2026-03-01' });
+      expect(ProyeccionService.willGenerateInMonth(e, 'trimestral', month('2026-04-01')).generates).toBe(false);
+    });
+
+    it('does NOT generate 2 months after start', () => {
+      const e = expense({ dia_de_pago: 15, fecha_inicio: '2026-03-01' });
+      expect(ProyeccionService.willGenerateInMonth(e, 'trimestral', month('2026-05-01')).generates).toBe(false);
+    });
+
+    it('does NOT generate before start date', () => {
+      const e = expense({ dia_de_pago: 15, fecha_inicio: '2026-03-01' });
+      expect(ProyeccionService.willGenerateInMonth(e, 'trimestral', month('2026-01-01')).generates).toBe(false);
+    });
+
+    it('does NOT generate without fecha_inicio', () => {
+      const e = expense({ dia_de_pago: 15, fecha_inicio: null });
+      expect(ProyeccionService.willGenerateInMonth(e, 'trimestral', month('2026-04-01')).generates).toBe(false);
+    });
+
+    it('works for Feb start crossing year boundary', () => {
+      const e = expense({ dia_de_pago: 15, fecha_inicio: '2025-11-01' });
+      // Nov 2025 → Feb 2026 = 3 months → should generate
+      expect(ProyeccionService.willGenerateInMonth(e, 'trimestral', month('2026-02-01')).generates).toBe(true);
+    });
+  });
+
+  // ─── SEMESTRAL ─────────────────────────────────────────────────────────────
+
+  describe('semestral', () => {
+    it('generates on the start month', () => {
+      const e = expense({ dia_de_pago: 15, fecha_inicio: '2026-03-01' });
+      expect(ProyeccionService.willGenerateInMonth(e, 'semestral', month('2026-03-01')).generates).toBe(true);
+    });
+
+    it('generates 6 months after start', () => {
+      const e = expense({ dia_de_pago: 15, fecha_inicio: '2026-03-01' });
+      expect(ProyeccionService.willGenerateInMonth(e, 'semestral', month('2026-09-01')).generates).toBe(true);
+    });
+
+    it('does NOT generate 3 months after start', () => {
+      const e = expense({ dia_de_pago: 15, fecha_inicio: '2026-03-01' });
+      expect(ProyeccionService.willGenerateInMonth(e, 'semestral', month('2026-06-01')).generates).toBe(false);
+    });
+
+    it('does NOT generate without fecha_inicio', () => {
+      const e = expense({ dia_de_pago: 15, fecha_inicio: null });
+      expect(ProyeccionService.willGenerateInMonth(e, 'semestral', month('2026-07-01')).generates).toBe(false);
+    });
+  });
+
+  // ─── BIMESTRAL ─────────────────────────────────────────────────────────────
+
+  describe('bimestral', () => {
+    it('generates on start month', () => {
+      const e = expense({ dia_de_pago: 10, fecha_inicio: '2026-02-01' });
+      expect(ProyeccionService.willGenerateInMonth(e, 'bimestral', month('2026-02-01')).generates).toBe(true);
+    });
+
+    it('generates 2 months after start', () => {
+      const e = expense({ dia_de_pago: 10, fecha_inicio: '2026-02-01' });
+      expect(ProyeccionService.willGenerateInMonth(e, 'bimestral', month('2026-04-01')).generates).toBe(true);
+    });
+
+    it('does NOT generate 1 month after start', () => {
+      const e = expense({ dia_de_pago: 10, fecha_inicio: '2026-02-01' });
+      expect(ProyeccionService.willGenerateInMonth(e, 'bimestral', month('2026-03-01')).generates).toBe(false);
+    });
+
+    it('works crossing year boundary (Nov start → Jan next year)', () => {
+      const e = expense({ dia_de_pago: 10, fecha_inicio: '2025-11-01' });
+      // Nov → Jan = 2 months → should generate
+      expect(ProyeccionService.willGenerateInMonth(e, 'bimestral', month('2026-01-01')).generates).toBe(true);
+    });
+  });
+
+  // ─── ANUAL ─────────────────────────────────────────────────────────────────
+
+  describe('anual', () => {
+    it('generates on correct month', () => {
+      const e = expense({ dia_de_pago: 10, mes_de_pago: 4, fecha_inicio: '2026-04-01' });
+      expect(ProyeccionService.willGenerateInMonth(e, 'anual', month('2026-04-01')).generates).toBe(true);
+    });
+
+    it('does NOT generate on wrong month', () => {
+      const e = expense({ dia_de_pago: 10, mes_de_pago: 4, fecha_inicio: '2026-04-01' });
+      expect(ProyeccionService.willGenerateInMonth(e, 'anual', month('2026-05-01')).generates).toBe(false);
+    });
+
+    it('generates same month next year', () => {
+      const e = expense({ dia_de_pago: 10, mes_de_pago: 4, fecha_inicio: '2026-04-01' });
+      expect(ProyeccionService.willGenerateInMonth(e, 'anual', month('2027-04-01')).generates).toBe(true);
+    });
+  });
+
+  // ─── MENSUAL (regression) ──────────────────────────────────────────────────
+
+  describe('mensual', () => {
+    it('generates every month', () => {
+      const e = expense({ dia_de_pago: 15, fecha_inicio: '2026-01-01' });
+      expect(ProyeccionService.willGenerateInMonth(e, 'mensual', month('2026-03-01')).generates).toBe(true);
+      expect(ProyeccionService.willGenerateInMonth(e, 'mensual', month('2026-07-01')).generates).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Problema

Tres bugs en la generación de gastos recurrentes con frecuencia trimestral, semestral y anual:

### Bug 1 — Trimestral y semestral ignoraban la fecha de inicio
`checkQuarterlyFrequency` siempre generaba en meses hardcodeados `[1, 4, 7, 10]` y `checkSemiannualFrequency` en `[1, 7]`, independientemente de cuándo el usuario creó el gasto.

**Ejemplo**: un gasto trimestral creado en febrero con `dia_de_pago=15` debería generar en Feb, May, Ago, Nov — pero el sistema lo saltaba hasta abril.

### Bug 2 — Sin prevención de duplicados para trimestral/semestral/anual
`shouldGenerateExpense` solo prevenía duplicados para `mensual`, `quincenal`, `semanal` y `diaria`. Para las frecuencias largas no había chequeo — si el scheduler reintentaba el mismo día, generaba el gasto dos veces.

### Bug 3 — Semestral hardcodeado a enero y julio
No respetaba el mes real de inicio del usuario.

## Solución

- **Trimestral y semestral**: ahora usan `ultima_fecha_generado` para calcular dinámicamente si ya pasaron 3/6 meses (igual que `bimestral` que ya lo hacía bien).
- **shouldGenerateExpense**: agrega chequeo de duplicados para `trimestral` (< 3 meses), `semestral` (< 6 meses) y `anual` (mismo año).

## Tests

19 tests nuevos en `tests/unit/services/gastoRecurrente.frequency.test.js` cubriendo:
- Primera generación (sin `ultima_fecha_generado`)
- Bloqueo antes del período mínimo
- Generación después del período correcto
- Prevención de duplicados por frecuencia
- Regresión: meses no hardcodeados (Feb trimestral = válido)

## Test plan

- [x] 19/19 unit tests pasando
- [ ] Verificar en staging que gastos existentes trimestral/semestral no se dupliquen tras el fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)