### PR TITLE
feat: TC histórico por mes en evolución mensual

### DIFF
--- a/docs/api/swagger.yaml
+++ b/docs/api/swagger.yaml
@@ -4999,7 +4999,19 @@ paths:
               schema:
                 type: object
                 properties:
-                  evolucion:
+                  balance_inicial:
+                    type: number
+                    description: Balance inicial configurado por el usuario en ARS
+                    example: 500000
+                  balance_actual_ars:
+                    type: number
+                    description: Acumulado del último mes en ARS
+                    example: 630000
+                  balance_actual_usd:
+                    type: number
+                    description: Acumulado del último mes en USD nativo
+                    example: 50
+                  meses:
                     type: array
                     items:
                       type: object
@@ -5014,24 +5026,24 @@ paths:
                         gastos_ars:
                           type: number
                           example: 120000
-                        balance_mes_ars:
+                        saldo_ars:
                           type: number
-                          description: Ingresos - Gastos del mes
+                          description: Ingresos - Gastos del mes en ARS
                           example: 30000
-                        balance_acumulado_ars:
+                        acumulado_ars:
                           type: number
-                          description: Balance acumulado incluyendo balance inicial
-                          example: 80000
+                          description: Balance acumulado incluyendo balance inicial en ARS
+                          example: 530000
                         ingresos_usd:
                           type: number
                           example: 0
                         gastos_usd:
                           type: number
                           example: 100
-                        balance_mes_usd:
+                        saldo_usd:
                           type: number
                           example: -100
-                        balance_acumulado_usd:
+                        acumulado_usd:
                           type: number
                           example: -100
                         tipo_cambio_mes:
@@ -5040,16 +5052,19 @@ paths:
                           description: TC de venta USD/ARS vigente al último día del mes. Null si no hay registro histórico.
                           example: 1350.50
               example:
-                evolucion:
+                balance_inicial: 500000
+                balance_actual_ars: 530000
+                balance_actual_usd: -100
+                meses:
                   - mes: '2026-01'
                     ingresos_ars: 150000
                     gastos_ars: 120000
-                    balance_mes_ars: 30000
-                    balance_acumulado_ars: 80000
+                    saldo_ars: 30000
+                    acumulado_ars: 530000
                     ingresos_usd: 0
                     gastos_usd: 100
-                    balance_mes_usd: -100
-                    balance_acumulado_usd: -100
+                    saldo_usd: -100
+                    acumulado_usd: -100
                     tipo_cambio_mes: 1350.50
         '400':
           description: Parámetros de fecha inválidos

--- a/docs/api/swagger.yaml
+++ b/docs/api/swagger.yaml
@@ -5034,6 +5034,11 @@ paths:
                         balance_acumulado_usd:
                           type: number
                           example: -100
+                        tipo_cambio_mes:
+                          type: number
+                          nullable: true
+                          description: TC de venta USD/ARS vigente al último día del mes. Null si no hay registro histórico.
+                          example: 1350.50
               example:
                 evolucion:
                   - mes: '2026-01'
@@ -5045,6 +5050,7 @@ paths:
                     gastos_usd: 100
                     balance_mes_usd: -100
                     balance_acumulado_usd: -100
+                    tipo_cambio_mes: 1350.50
         '400':
           description: Parámetros de fecha inválidos
           content:

--- a/src/services/balance.service.js
+++ b/src/services/balance.service.js
@@ -2,6 +2,7 @@ import { IngresoRecurrente } from '../models/index.js';
 import { sequelize } from '../models/index.js';
 import { QueryTypes } from 'sequelize';
 import { getOrCreatePreferencias } from './preferenciasUsuario.service.js';
+import { ExchangeRateService } from './exchangeRate.service.js';
 
 /**
  * Obtiene la evolución mensual del balance de un usuario
@@ -95,6 +96,19 @@ export async function getEvolucionMensual(usuarioId, desde, hasta) {
   let acumuladoArs = balanceInicial + saldoPrevioArs;
   let acumuladoUsd = saldoPrevioUsd;
 
+  // Obtener TC histórico para cada mes en paralelo (usa el último día del mes como referencia)
+  const tcPorMes = await Promise.all(
+    meses.map(async mes => {
+      try {
+        const tc = await ExchangeRateService.getRateForDate(getLastDayOfMonth(mes));
+        return { mes, tc_venta: parseFloat(tc.valor_venta_usd_ars) };
+      } catch {
+        return { mes, tc_venta: null };
+      }
+    })
+  );
+  const tcMap = new Map(tcPorMes.map(({ mes, tc_venta }) => [mes, tc_venta]));
+
   const evolucion = meses.map(mes => {
     const gastos = gastosMap.get(mes) || { total_ars: 0, total_usd: 0 };
     const ingresosU = ingresosUnicosMap.get(mes) || { total_ars: 0, total_usd: 0 };
@@ -135,7 +149,8 @@ export async function getEvolucionMensual(usuarioId, desde, hasta) {
       ingresos_usd: round2(totalIngresosUsd),
       gastos_usd: round2(totalGastosUsd),
       saldo_usd: round2(saldoUsd),
-      acumulado_usd: round2(acumuladoUsd)
+      acumulado_usd: round2(acumuladoUsd),
+      tipo_cambio_mes: tcMap.get(mes) ?? null
     };
   });
 

--- a/tests/unit/services/balance.service.test.js
+++ b/tests/unit/services/balance.service.test.js
@@ -11,6 +11,7 @@ const mockIngresoRecurrente = {
 };
 
 const mockGetOrCreatePreferencias = jest.fn();
+const mockGetRateForDate = jest.fn();
 
 jest.unstable_mockModule('../../../src/models/index.js', () => ({
   sequelize: mockSequelize,
@@ -19,6 +20,12 @@ jest.unstable_mockModule('../../../src/models/index.js', () => ({
 
 jest.unstable_mockModule('../../../src/services/preferenciasUsuario.service.js', () => ({
   getOrCreatePreferencias: mockGetOrCreatePreferencias
+}));
+
+jest.unstable_mockModule('../../../src/services/exchangeRate.service.js', () => ({
+  ExchangeRateService: {
+    getRateForDate: mockGetRateForDate
+  }
 }));
 
 const {
@@ -73,6 +80,8 @@ function setupMocks({
 describe('Balance Service', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    // Default: TC available for every month
+    mockGetRateForDate.mockResolvedValue({ valor_venta_usd_ars: '1350.00' });
   });
 
   // ==========================================
@@ -317,6 +326,56 @@ describe('Balance Service', () => {
       // Plus 50k recurring in April itself
       // acumulado = 500k + 150k (saldo previo recurrentes) + 50k (recurrente in Apr) = 700k
       expect(result.meses[0].acumulado_ars).toBe(700000);
+    });
+
+    // ─── tipo_cambio_mes ────────────────────────────────────────────────────────
+
+    it('should include tipo_cambio_mes from ExchangeRateService in each month', async () => {
+      mockGetRateForDate.mockResolvedValue({ valor_venta_usd_ars: '1350.50' });
+      setupMocks();
+
+      const result = await getEvolucionMensual(usuarioId, '2026-04', '2026-04');
+
+      expect(result.meses[0].tipo_cambio_mes).toBe(1350.50);
+      expect(mockGetRateForDate).toHaveBeenCalledWith('2026-04-30');
+    });
+
+    it('should use last day of each month when fetching TC', async () => {
+      mockGetRateForDate
+        .mockResolvedValueOnce({ valor_venta_usd_ars: '1300.00' }) // Jan
+        .mockResolvedValueOnce({ valor_venta_usd_ars: '1400.00' }); // Feb
+      setupMocks();
+
+      const result = await getEvolucionMensual(usuarioId, '2026-01', '2026-02');
+
+      expect(mockGetRateForDate).toHaveBeenCalledWith('2026-01-31');
+      expect(mockGetRateForDate).toHaveBeenCalledWith('2026-02-28');
+      expect(result.meses[0].tipo_cambio_mes).toBe(1300);
+      expect(result.meses[1].tipo_cambio_mes).toBe(1400);
+    });
+
+    it('should set tipo_cambio_mes to null when ExchangeRateService throws', async () => {
+      mockGetRateForDate.mockRejectedValue(new Error('No TC found'));
+      setupMocks();
+
+      const result = await getEvolucionMensual(usuarioId, '2026-04', '2026-04');
+
+      expect(result.meses[0].tipo_cambio_mes).toBeNull();
+    });
+
+    it('should not affect ARS balance calculations when TC is unavailable', async () => {
+      mockGetRateForDate.mockRejectedValue(new Error('No TC found'));
+      setupMocks({
+        gastosPorMes: [{ mes: '2026-04', total_ars: '100000', total_usd: '0' }],
+        ingresosUnicosPorMes: [{ mes: '2026-04', total_ars: '150000', total_usd: '0' }],
+      });
+
+      const result = await getEvolucionMensual(usuarioId, '2026-04', '2026-04');
+
+      // ARS balance unaffected
+      expect(result.meses[0].saldo_ars).toBe(50000);
+      expect(result.meses[0].acumulado_ars).toBe(550000);
+      expect(result.meses[0].tipo_cambio_mes).toBeNull();
     });
   });
 });


### PR DESCRIPTION
## Summary
- `balance.service.js` ahora busca el TC histórico para el último día de cada mes via `ExchangeRateService.getRateForDate()`
- Cada fila de la respuesta incluye `tipo_cambio_mes` (TC de venta USD/ARS). Retorna `null` si no hay registro histórico para ese período
- Swagger actualizado con el nuevo campo

## Why
Antes, el frontend usaba el TC actual para convertir todos los meses históricos, lo cual era incorrecto. Ahora cada mes usa el TC vigente en ese período.

## Test plan
- [ ] Verificar que GET /balance/evolucion incluye `tipo_cambio_mes` en cada mes
- [ ] Verificar que meses sin TC histórico retornan `null` (no falla)
- [ ] Verificar que el acumulado en ARS no cambió (el TC solo afecta la conversión display)

🤖 Generated with [Claude Code](https://claude.com/claude-code)